### PR TITLE
[PG14] Optimize prefetch patterns in both heap seqscan and vacuum scans.

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -400,19 +400,32 @@ heapgetpage(TableScanDesc sscan, BlockNumber page)
 	CHECK_FOR_INTERRUPTS();
 
 	/* Prefetch next block */
-	if (enable_seqscan_prefetch)
+	if (enable_seqscan_prefetch && seqscan_prefetch_buffers > 0)
 	{
-		int prefetch_limit = seqscan_prefetch_buffers;
+		uint32 prefetch_limit = seqscan_prefetch_buffers;
+		BlockNumber	prefetch_start = page;
 		ParallelBlockTableScanWorker pbscanwork = scan->rs_parallelworkerdata;
+
 		if (pbscanwork != NULL && pbscanwork->phsw_chunk_remaining < prefetch_limit)
 			prefetch_limit = pbscanwork->phsw_chunk_remaining;
-		if (page + prefetch_limit >= scan->rs_nblocks)
-			prefetch_limit = scan->rs_nblocks - page - 1;
+
+		/*
+		 * If this is the first page, initiate prefetch of pages page..page + n.
+		 * On each subsequent call, prefetch the next page that we haven't
+		 * prefetched yet, at page + n.
+		 */
+		if (scan->rs_startblock != page)
+		{
+			prefetch_start = (page + prefetch_limit - 1) % scan->rs_nblocks;
+			prefetch_limit = 1;
+		}
+		else
+			prefetch_start = page;
 
 		RelationOpenSmgr(scan->rs_base.rs_rd);
-		smgr_reset_prefetch(scan->rs_base.rs_rd->rd_smgr);
 		for (int i = 1; i <= prefetch_limit; i++)
-			PrefetchBuffer(scan->rs_base.rs_rd, MAIN_FORKNUM, page+i);
+			PrefetchBuffer(scan->rs_base.rs_rd, MAIN_FORKNUM,
+						   (prefetch_start+i) % scan->rs_nblocks);
 	}
 
 	/* read page using selected strategy */

--- a/src/backend/storage/smgr/smgr.c
+++ b/src/backend/storage/smgr/smgr.c
@@ -38,7 +38,6 @@ static const f_smgr smgr_md = {
 		.smgr_unlink = mdunlink,
 		.smgr_extend = mdextend,
 		.smgr_prefetch = mdprefetch,
-		.smgr_reset_prefetch = md_reset_prefetch,
 		.smgr_read = mdread,
 		.smgr_write = mdwrite,
 		.smgr_writeback = mdwriteback,
@@ -499,15 +498,6 @@ bool
 smgrprefetch(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum)
 {
 	return (*reln->smgr).smgr_prefetch(reln, forknum, blocknum);
-}
-
-/*
- *	smgr_reset_prefetch() -- Cancel all previos prefetch requests
- */
-void
-smgr_reset_prefetch(SMgrRelation reln)
-{
-	(*reln->smgr).smgr_reset_prefetch(reln);
 }
 
 /*

--- a/src/include/storage/smgr.h
+++ b/src/include/storage/smgr.h
@@ -157,7 +157,6 @@ extern void smgrextend(SMgrRelation reln, ForkNumber forknum,
 					   BlockNumber blocknum, char *buffer, bool skipFsync);
 extern bool smgrprefetch(SMgrRelation reln, ForkNumber forknum,
 						 BlockNumber blocknum);
-extern void smgr_reset_prefetch(SMgrRelation reln);
 extern void smgrread(SMgrRelation reln, ForkNumber forknum,
 					 BlockNumber blocknum, char *buffer);
 extern void smgrwrite(SMgrRelation reln, ForkNumber forknum,


### PR DESCRIPTION
Previously, we called PrefetchBuffer [NBlkScanned * seqscan_prefetch_buffers] times in each of those situations, but now only NBlkScanned.

In addition, the prefetch mechanism for the vacuum scans is now based on blocks instead of tuples - improving the efficiency.

companion pr to https://github.com/neondatabase/neon/pull/2687