### PR TITLE
Fix uninitialized variable in spgvacuum.c

### DIFF
--- a/src/backend/access/spgist/spgvacuum.c
+++ b/src/backend/access/spgist/spgvacuum.c
@@ -829,6 +829,8 @@ spgvacuumscan(spgBulkDeleteState *bds)
 	 * in btvacuumscan().
 	 */
 	blkno = SPGIST_METAPAGE_BLKNO + 1;
+	prefetch_blkno = blkno;
+
 	for (;;)
 	{
 		/* Get the current relation length */


### PR DESCRIPTION
The compiler warning was correct and would have the potential to disable prefetching.