### PR TITLE
Restore running xacts from CLOG on replica startup

### DIFF
--- a/src/backend/access/transam/xlogrecovery.c
+++ b/src/backend/access/transam/xlogrecovery.c
@@ -804,7 +804,29 @@ InitWalRecovery(ControlFileData *ControlFile, bool *wasShutdown_ptr,
 		//EndRecPtr = ControlFile->checkPointCopy.redo;
 
 		memcpy(&checkPoint, &ControlFile->checkPointCopy, sizeof(CheckPoint));
-		wasShutdown = true;
+
+		/*
+		 * When a primary Neon compute node is started, we pretend that it
+		 * started after a clean shutdown and no recovery is needed. We don't
+		 * need to do WAL replay, the page server does that on a page-by-page
+		 * basis.
+		 *
+		 * When starting a read-only replica, we will also start from a
+		 * consistent snapshot of the cluster the start LSN, so we don't need
+		 * to perform WAL replay to get there. However, wasShutdown must be
+		 * set to false, because wasShutdown==true would imply that there are
+		 * no transactions still in-progress at the start LSN, and we would
+		 * initialize the known-assigned XIDs machinery for hot standby
+		 * incorrectly. If this is a static read-only node that doesn't follow
+		 * the primary though, then it's OK.
+		 */
+		if (StandbyModeRequested &&
+			PrimaryConnInfo != NULL && *PrimaryConnInfo != '\0')
+		{
+			wasShutdown = false;
+		}
+		else
+			wasShutdown = true;
 
 		/* Initialize expectedTLEs, like ReadRecord() does */
 		expectedTLEs = readTimeLineHistory(checkPoint.ThisTimeLineID);

--- a/src/backend/access/transam/xlogrecovery.c
+++ b/src/backend/access/transam/xlogrecovery.c
@@ -803,6 +803,22 @@ InitWalRecovery(ControlFileData *ControlFile, bool *wasShutdown_ptr,
 		SetRedoStartLsn(RedoStartLSN);
 		//EndRecPtr = ControlFile->checkPointCopy.redo;
 
+		if (!TransactionIdIsNormal(ControlFile->checkPointCopy.oldestActiveXid))
+		{
+			/*
+			 * No checkpoint or running-xacts record was written, so use most
+			 * conservative approximation for oldestActiveXid:
+			 * firstNormalTransactionId.  There are should not be problems
+			 * with wraparounf because it is not possible that XID is
+			 * overflown without writting any checkpoint or running-xact
+			 * record.
+			 *
+			 * HEIKKI: I don't understand this. Why is it not always set
+			 * correctly in the checkpoint?
+			 */
+			ControlFile->checkPointCopy.oldestActiveXid = FirstNormalTransactionId;
+		}
+
 		memcpy(&checkPoint, &ControlFile->checkPointCopy, sizeof(CheckPoint));
 
 		/*


### PR DESCRIPTION
See https://github.com/neondatabase/neon/issues/6211