### PR TITLE
Fix -Warray-bounds warning in guc_var_compare() function

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -5809,10 +5809,10 @@ find_option(const char *name, bool create_placeholders, bool skip_errors,
 static int
 guc_var_compare(const void *a, const void *b)
 {
-	const struct config_generic *confa = *(struct config_generic *const *) a;
-	const struct config_generic *confb = *(struct config_generic *const *) b;
+	const char *confa_name = **(char **const *) a;
+	const char *confb_name = **(char **const *) b;
 
-	return guc_name_compare(confa->name, confb->name);
+	return guc_name_compare(confa_name, confb_name);
 }
 
 /*


### PR DESCRIPTION
There are a couple of places that guc_var_compare() function takes 'const char ***' type and then casts it to the
'const struct config_generic *' type. This triggers '-Warray-bounds' warning. So, instead cast them to the 'const char *' type.

Ref: https://www.postgresql.org/message-id/attachment/160118/v1-0001-Fix-Warray-bounds-warning-in-guc_var_compare-func.patch