### PR TITLE
Undo changes in Postgres core for building GIST/GIN indexes

### DIFF
--- a/src/backend/access/gin/gininsert.c
+++ b/src/backend/access/gin/gininsert.c
@@ -335,8 +335,6 @@ ginbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 		elog(ERROR, "index \"%s\" already contains data",
 			 RelationGetRelationName(index));
 
-	smgr_start_unlogged_build(index->rd_smgr);
-
 	initGinState(&buildstate.ginstate, index);
 	buildstate.indtuples = 0;
 	memset(&buildstate.buildStats, 0, sizeof(GinStatsData));
@@ -410,8 +408,6 @@ ginbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 	buildstate.buildStats.nTotalPages = RelationGetNumberOfBlocks(index);
 	ginUpdateStats(index, &buildstate.buildStats, true);
 
-	smgr_finish_unlogged_build_phase_1(index->rd_smgr);
-
 	/*
 	 * We didn't write WAL records as we built the index, so if WAL-logging is
 	 * required, write all pages to the WAL now.
@@ -421,11 +417,7 @@ ginbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 		log_newpage_range(index, MAIN_FORKNUM,
 						  0, RelationGetNumberOfBlocks(index),
 						  true);
-		SetLastWrittenLSNForBlockRange(XactLastRecEnd, index->rd_smgr->smgr_rlocator.locator, MAIN_FORKNUM, 0, RelationGetNumberOfBlocks(index));
-		SetLastWrittenLSNForRelation(XactLastRecEnd, index->rd_smgr->smgr_rlocator.locator, MAIN_FORKNUM);
 	}
-
-	smgr_end_unlogged_build(index->rd_smgr);
 
 	/*
 	 * Return statistics

--- a/src/backend/access/gist/gistbuild.c
+++ b/src/backend/access/gist/gistbuild.c
@@ -298,8 +298,6 @@ gistbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 		Buffer		buffer;
 		Page		page;
 
-		smgr_start_unlogged_build(index->rd_smgr);
-
 		/* initialize the root page */
 		buffer = gistNewBuffer(index, heap);
 		Assert(BufferGetBlockNumber(buffer) == GIST_ROOT_BLKNO);
@@ -332,8 +330,6 @@ gistbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 			gistFreeBuildBuffers(buildstate.gfbb);
 		}
 
-		smgr_finish_unlogged_build_phase_1(index->rd_smgr);
-
 		/*
 		 * We didn't write WAL records as we built the index, so if
 		 * WAL-logging is required, write all pages to the WAL now.
@@ -343,13 +339,7 @@ gistbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 			log_newpage_range(index, MAIN_FORKNUM,
 							  0, RelationGetNumberOfBlocks(index),
 							  true);
-			SetLastWrittenLSNForBlockRange(XactLastRecEnd,
-							  index->rd_smgr->smgr_rlocator.locator,
-							  MAIN_FORKNUM, 0, RelationGetNumberOfBlocks(index));
-			SetLastWrittenLSNForRelation(XactLastRecEnd, index->rd_smgr->smgr_rlocator.locator, MAIN_FORKNUM);
 		}
-
-		smgr_end_unlogged_build(index->rd_smgr);
 	}
 
 	/* okay, all heap tuples are indexed */

--- a/src/backend/access/gist/gistutil.c
+++ b/src/backend/access/gist/gistutil.c
@@ -793,13 +793,15 @@ gistcheckpage(Relation rel, Buffer buf)
 	 * case, however.
 	 */
 	if (PageIsNew(page))
+	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INDEX_CORRUPTED),
-				 errmsg("index \"%s\" contains unexpected zero page at block %u",
+				 errmsg("index \"%s\" (%d) contains unexpected zero page at block %u",
 						RelationGetRelationName(rel),
+						RelationGetRelid(rel),
 						BufferGetBlockNumber(buf)),
 				 errhint("Please REINDEX it.")));
-
+	}
 	/*
 	 * Additionally check that the special area looks sane.
 	 */

--- a/src/backend/storage/smgr/smgr.c
+++ b/src/backend/storage/smgr/smgr.c
@@ -726,30 +726,6 @@ smgrimmedsync(SMgrRelation reln, ForkNumber forknum)
 }
 
 /*
- * Neon-added functions to mark the phases of an unlogged index build.
- */
-void
-smgr_start_unlogged_build(SMgrRelation reln)
-{
-	if ((*reln->smgr).smgr_start_unlogged_build)
-		(*reln->smgr).smgr_start_unlogged_build(reln);
-}
-
-void
-smgr_finish_unlogged_build_phase_1(SMgrRelation reln)
-{
-	if ((*reln->smgr).smgr_finish_unlogged_build_phase_1)
-		(*reln->smgr).smgr_finish_unlogged_build_phase_1(reln);
-}
-
-void
-smgr_end_unlogged_build(SMgrRelation reln)
-{
-	if ((*reln->smgr).smgr_end_unlogged_build)
-		(*reln->smgr).smgr_end_unlogged_build(reln);
-}
-
-/*
  * NEON: we do not want to include large pg_xact/multixact files in basebackup and prefer
  * to download them on demand to reduce startup time.
  * If SLRU segment is not found, we try to download it from page server

--- a/src/include/access/xloginsert.h
+++ b/src/include/access/xloginsert.h
@@ -67,4 +67,8 @@ extern XLogRecPtr XLogSaveBufferForHint(Buffer buffer, bool buffer_std);
 
 extern void InitXLogInsert(void);
 
+typedef void (*log_newpage_range_callback_t)(Relation rel, ForkNumber forknum);
+extern log_newpage_range_callback_t log_newpage_range_callback;
+
+
 #endif							/* XLOGINSERT_H */

--- a/src/include/storage/smgr.h
+++ b/src/include/storage/smgr.h
@@ -127,10 +127,6 @@ typedef struct f_smgr
 								  BlockNumber nblocks);
 	void		(*smgr_immedsync) (SMgrRelation reln, ForkNumber forknum);
 
-	void		(*smgr_start_unlogged_build) (SMgrRelation reln);
-	void		(*smgr_finish_unlogged_build_phase_1) (SMgrRelation reln);
-	void		(*smgr_end_unlogged_build) (SMgrRelation reln);
-
 	int  		(*smgr_read_slru_segment) (SMgrRelation reln, const char *path, int segno, void* buffer);
 } f_smgr;
 


### PR DESCRIPTION
Some Postgres indexes (GIN,GIST,SPGIST...) are using two-phase build: at first phase relation pages are constructed and at second phase - all relation is wal-logged. It doesn't work with Neon because if dirty page was thrown away from shared buffer before been wal-logged, then its content will be lost.

We have added support of unlogged builds to SMGR API. But it requires changes in Postgre core. What is even worser some extensions (i.e. pgvector) are also using the same policy and have to be patched.

This PR tries to avoid changes in Postgres core and did it at Neon extension level.