### PR TITLE
Undo changes in Postgres core for building GIST/GIN indexes

### DIFF
--- a/src/backend/access/gin/gininsert.c
+++ b/src/backend/access/gin/gininsert.c
@@ -335,8 +335,6 @@ ginbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 		elog(ERROR, "index \"%s\" already contains data",
 			 RelationGetRelationName(index));
 
-	smgr_start_unlogged_build(index->rd_smgr);
-
 	initGinState(&buildstate.ginstate, index);
 	buildstate.indtuples = 0;
 	memset(&buildstate.buildStats, 0, sizeof(GinStatsData));
@@ -410,8 +408,6 @@ ginbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 	buildstate.buildStats.nTotalPages = RelationGetNumberOfBlocks(index);
 	ginUpdateStats(index, &buildstate.buildStats, true);
 
-	smgr_finish_unlogged_build_phase_1(index->rd_smgr);
-
 	/*
 	 * We didn't write WAL records as we built the index, so if WAL-logging is
 	 * required, write all pages to the WAL now.
@@ -421,11 +417,7 @@ ginbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 		log_newpage_range(index, MAIN_FORKNUM,
 						  0, RelationGetNumberOfBlocks(index),
 						  true);
-		SetLastWrittenLSNForBlockRange(XactLastRecEnd, index->rd_smgr->smgr_rnode.node, MAIN_FORKNUM, 0, RelationGetNumberOfBlocks(index));
-		SetLastWrittenLSNForRelation(XactLastRecEnd, index->rd_smgr->smgr_rnode.node, MAIN_FORKNUM);
 	}
-
-	smgr_end_unlogged_build(index->rd_smgr);
 
 	/*
 	 * Return statistics

--- a/src/backend/access/gist/gistbuild.c
+++ b/src/backend/access/gist/gistbuild.c
@@ -297,8 +297,6 @@ gistbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 		Buffer		buffer;
 		Page		page;
 
-		smgr_start_unlogged_build(index->rd_smgr);
-
 		/* initialize the root page */
 		buffer = gistNewBuffer(index);
 		Assert(BufferGetBlockNumber(buffer) == GIST_ROOT_BLKNO);
@@ -331,8 +329,6 @@ gistbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 			gistFreeBuildBuffers(buildstate.gfbb);
 		}
 
-		smgr_finish_unlogged_build_phase_1(index->rd_smgr);
-
 		/*
 		 * We didn't write WAL records as we built the index, so if
 		 * WAL-logging is required, write all pages to the WAL now.
@@ -342,12 +338,7 @@ gistbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 			log_newpage_range(index, MAIN_FORKNUM,
 							  0, RelationGetNumberOfBlocks(index),
 							  true);
-			SetLastWrittenLSNForBlockRange(XactLastRecEnd,
-							  index->rd_smgr->smgr_rnode.node,
-							  MAIN_FORKNUM, 0, RelationGetNumberOfBlocks(index));
-			SetLastWrittenLSNForRelation(XactLastRecEnd, index->rd_smgr->smgr_rnode.node, MAIN_FORKNUM);
 		}
-		smgr_end_unlogged_build(index->rd_smgr);
 	}
 
 	/* okay, all heap tuples are indexed */

--- a/src/backend/access/spgist/spginsert.c
+++ b/src/backend/access/spgist/spginsert.c
@@ -85,8 +85,6 @@ spgbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 		elog(ERROR, "index \"%s\" already contains data",
 			 RelationGetRelationName(index));
 
-	smgr_start_unlogged_build(index->rd_smgr);
-
 	/*
 	 * Initialize the meta page and root pages
 	 */
@@ -133,8 +131,6 @@ spgbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 
 	SpGistUpdateMetaPage(index);
 
-	smgr_finish_unlogged_build_phase_1(index->rd_smgr);
-
 	/*
 	 * We didn't write WAL records as we built the index, so if WAL-logging is
 	 * required, write all pages to the WAL now.
@@ -144,12 +140,7 @@ spgbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 		log_newpage_range(index, MAIN_FORKNUM,
 						  0, RelationGetNumberOfBlocks(index),
 						  true);
-		SetLastWrittenLSNForBlockRange(XactLastRecEnd, index->rd_smgr->smgr_rnode.node,
-						  MAIN_FORKNUM, 0, RelationGetNumberOfBlocks(index));
-		SetLastWrittenLSNForRelation(XactLastRecEnd, index->rd_smgr->smgr_rnode.node, MAIN_FORKNUM);
 	}
-
-	smgr_end_unlogged_build(index->rd_smgr);
 
 	result = (IndexBuildResult *) palloc0(sizeof(IndexBuildResult));
 	result->heap_tuples = reltuples;

--- a/src/backend/access/transam/xloginsert.c
+++ b/src/backend/access/transam/xloginsert.c
@@ -41,6 +41,7 @@
 #include "storage/bufmgr.h"
 #include "storage/proc.h"
 #include "utils/memutils.h"
+#include "utils/rel.h"
 #include "utils/wait_event.h"
 
 /*
@@ -93,6 +94,8 @@ typedef struct
 int			max_replication_apply_lag;
 int			max_replication_flush_lag;
 int			max_replication_write_lag;
+
+log_newpage_range_callback_t log_newpage_range_callback;
 
 static registered_buffer *registered_buffers;
 static int	max_registered_buffers; /* allocated size */
@@ -1244,6 +1247,7 @@ log_newpage_range(Relation rel, ForkNumber forkNum,
 		XLogRecPtr	recptr;
 		int			nbufs;
 		int			i;
+		BlockNumber firstblk = blkno;
 
 		CHECK_FOR_INTERRUPTS();
 
@@ -1274,7 +1278,6 @@ log_newpage_range(Relation rel, ForkNumber forkNum,
 
 		/* Write WAL record for this batch. */
 		XLogBeginInsert();
-
 		START_CRIT_SECTION();
 		for (i = 0; i < nbufs; i++)
 		{
@@ -1283,7 +1286,9 @@ log_newpage_range(Relation rel, ForkNumber forkNum,
 		}
 
 		recptr = XLogInsert(RM_XLOG_ID, XLOG_FPI);
-
+		SetLastWrittenLSNForBlockRange(recptr, rel->rd_smgr->smgr_rnode.node,
+									   forkNum, firstblk, blkno - firstblk);
+		SetLastWrittenLSNForRelation(recptr, rel->rd_smgr->smgr_rnode.node, forkNum);
 		for (i = 0; i < nbufs; i++)
 		{
 			PageSetLSN(BufferGetPage(bufpack[i]), recptr);
@@ -1291,6 +1296,8 @@ log_newpage_range(Relation rel, ForkNumber forkNum,
 		}
 		END_CRIT_SECTION();
 	}
+	if (log_newpage_range_callback)
+		log_newpage_range_callback(rel, forkNum);
 }
 
 /*

--- a/src/backend/storage/smgr/smgr.c
+++ b/src/backend/storage/smgr/smgr.c
@@ -723,30 +723,6 @@ smgrimmedsync(SMgrRelation reln, ForkNumber forknum)
 }
 
 /*
- * Zenith-added functions to mark the phases of an unlogged index build.
- */
-void
-smgr_start_unlogged_build(SMgrRelation reln)
-{
-	if ((*reln->smgr).smgr_start_unlogged_build)
-		(*reln->smgr).smgr_start_unlogged_build(reln);
-}
-
-void
-smgr_finish_unlogged_build_phase_1(SMgrRelation reln)
-{
-	if ((*reln->smgr).smgr_finish_unlogged_build_phase_1)
-		(*reln->smgr).smgr_finish_unlogged_build_phase_1(reln);
-}
-
-void
-smgr_end_unlogged_build(SMgrRelation reln)
-{
-	if ((*reln->smgr).smgr_end_unlogged_build)
-		(*reln->smgr).smgr_end_unlogged_build(reln);
-}
-
-/*
  * AtEOXact_SMgr
  *
  * This routine is called during transaction commit or abort (it doesn't

--- a/src/include/access/xloginsert.h
+++ b/src/include/access/xloginsert.h
@@ -67,4 +67,8 @@ extern XLogRecPtr XLogSaveBufferForHint(Buffer buffer, bool buffer_std);
 
 extern void InitXLogInsert(void);
 
+typedef void (*log_newpage_range_callback_t)(Relation rel, ForkNumber forknum);
+extern log_newpage_range_callback_t log_newpage_range_callback;
+
+
 #endif							/* XLOGINSERT_H */

--- a/src/include/storage/smgr.h
+++ b/src/include/storage/smgr.h
@@ -124,11 +124,6 @@ typedef struct f_smgr
 								  BlockNumber nblocks);
 	void		(*smgr_immedsync) (SMgrRelation reln, ForkNumber forknum);
 
-	void		(*smgr_reset_prefetch) (SMgrRelation reln);
-	void		(*smgr_start_unlogged_build) (SMgrRelation reln);
-	void		(*smgr_finish_unlogged_build_phase_1) (SMgrRelation reln);
-	void		(*smgr_end_unlogged_build) (SMgrRelation reln);
-
 	int  		(*smgr_read_slru_segment) (SMgrRelation reln, const char *path, int segno, void* buffer);
 } f_smgr;
 


### PR DESCRIPTION
Some Postgres indexes (GIN,GIST,SPGIST...) are using two-phase build: at first phase relation pages are constructed and at second phase - all relation is wal-logged. It doesn't work with Neon because if dirty page was thrown away from shared buffer before been wal-logged, then its content will be lost.

We have added support of unlogged builds to SMGR API. But it requires changes in Postgre core. What is even worser some extensions (i.e. pgvector) are also using the same policy and have to be patched.

This PR tries to avoid changes in Postgres core and did it at Neon extension level.