### PR TITLE
Fix: Don't flush a buffer in am_wal_redo_postgres mode

### DIFF
--- a/src/backend/access/hash/hash_xlog.c
+++ b/src/backend/access/hash/hash_xlog.c
@@ -52,7 +52,7 @@ hash_xlog_init_meta_page(XLogReaderState *record)
 	 * full page image of the metapage.
 	 */
 	XLogRecGetBlockTag(record, 0, NULL, &forknum, NULL);
-	if (forknum == INIT_FORKNUM)
+	if (forknum == INIT_FORKNUM && !am_wal_redo_postgres)
 		FlushOneBuffer(metabuf);
 
 	/* all done */
@@ -90,7 +90,7 @@ hash_xlog_init_bitmap_page(XLogReaderState *record)
 	 * full page image of the metapage.
 	 */
 	XLogRecGetBlockTag(record, 0, NULL, &forknum, NULL);
-	if (forknum == INIT_FORKNUM)
+	if (forknum == INIT_FORKNUM && !am_wal_redo_postgres)
 		FlushOneBuffer(bitmapbuf);
 	UnlockReleaseBuffer(bitmapbuf);
 
@@ -114,7 +114,7 @@ hash_xlog_init_bitmap_page(XLogReaderState *record)
 		MarkBufferDirty(metabuf);
 
 		XLogRecGetBlockTag(record, 1, NULL, &forknum, NULL);
-		if (forknum == INIT_FORKNUM)
+		if (forknum == INIT_FORKNUM && !am_wal_redo_postgres)
 			FlushOneBuffer(metabuf);
 	}
 	if (BufferIsValid(metabuf))

--- a/src/backend/access/transam/xlogutils.c
+++ b/src/backend/access/transam/xlogutils.c
@@ -430,7 +430,7 @@ XLogReadBufferForRedoExtended(XLogReaderState *record,
 		 * force the on-disk state of init forks to always be in sync with the
 		 * state in shared buffers.
 		 */
-		if (forknum == INIT_FORKNUM)
+		if (forknum == INIT_FORKNUM && !am_wal_redo_postgres)
 			FlushOneBuffer(*buf);
 
 		return BLK_RESTORED;


### PR DESCRIPTION
WalRedoPostgres operates on private buffers, which causes issues with FlushOneBuffer, which expects to handle only shared buffers.