### PR TITLE
PG14: Fix timeout value used in XLogWaitForReplayOf

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -5390,7 +5390,7 @@ XLogWaitForReplayOf(XLogRecPtr redoEndRecPtr)
 	{
 		bool timeout;
 		timeout = ConditionVariableTimedSleep(&XLogCtl->replayProgressCV,
-											  10000000,
+											  10000, /* 10 seconds, in millis */
 											  WAIT_EVENT_RECOVERY_WAL_STREAM);
 
 		if (timeout)


### PR DESCRIPTION
The previous value assumed usec precision, while the timeout used is in milliseconds, causing replica backends to wait for many hours for WAL replay without the expected progress reports in logs.

This fixes the issue.

Reported-By: Alexander Lakhin <exclusion@gmail.com>

https://github.com/neondatabase/neon/pull/9937