### PR TITLE
PG15: Fix timeout value used in XLogWaitForReplayOf

### DIFF
--- a/src/backend/access/transam/xlogrecovery.c
+++ b/src/backend/access/transam/xlogrecovery.c
@@ -531,7 +531,7 @@ XLogWaitForReplayOf(XLogRecPtr redoEndRecPtr)
 	{
 		bool timeout;
 		timeout = ConditionVariableTimedSleep(&XLogRecoveryCtl->replayProgressCV,
-											  10000000, /* 10 seconds */
+											  10000, /* 10 seconds, in millis */
 											  WAIT_EVENT_RECOVERY_WAL_STREAM);
 
 		replayRecPtr = GetXLogReplayRecPtr(NULL);


### PR DESCRIPTION
The previous value assumed usec precision, while the timeout used is in milliseconds, causing replica backends to wait for many hours for WAL replay without the expected progress reports in logs.

This fixes the issue.

Reported-By: Alexander Lakhin <exclusion@gmail.com>

https://github.com/neondatabase/neon/pull/9937