### PR TITLE
Do not drop tablesync replication slots on the publisher,

### DIFF
--- a/src/backend/commands/subscriptioncmds.c
+++ b/src/backend/commands/subscriptioncmds.c
@@ -1728,7 +1728,17 @@ DropSubscription(DropSubscriptionStmt *stmt, bool isTopLevel)
 
 				ReplicationSlotNameForTablesync(subid, relid, syncslotname,
 												sizeof(syncslotname));
-				ReplicationSlotDropAtPubNode(wrconn, syncslotname, true);
+
+				if (disable_logical_replication_subscribers)
+				{
+					ereport(LOG,
+							(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+								errmsg("skip dropping tablesync slot \"%s\" when disable_logical_replication_subscribers=true", syncslotname)));
+				}
+				else
+				{
+					ReplicationSlotDropAtPubNode(wrconn, syncslotname, true);
+				}
 			}
 		}
 


### PR DESCRIPTION
when we're in the process of dropping subscriptions inherited by a neon branch.
Because these slots are still needed by the parent branch subscriptions.

For regular slots we handle this by setting the slot_name to NONE before calling DROP SUBSCRIPTION, but tablesync slots are not exposed to SQL.

rely on GUC disable_logical_replication_subscribers=true to know that we're in the Neon-specific process of dropping subscriptions.