### PR TITLE
Fetch remote extension in ALTER EXTENSION UPDATE statements

### DIFF
--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -1214,9 +1214,11 @@ identify_update_path(ExtensionControlFile *control,
 {
 	List	   *result;
 	List	   *evi_list;
+	bool		attempted_download = false;
 	ExtensionVersionInfo *evi_start;
 	ExtensionVersionInfo *evi_target;
 
+reidentify:
 	/* Extract the version update graph from the script directory */
 	evi_list = get_ext_ver_list(control);
 
@@ -1226,6 +1228,16 @@ identify_update_path(ExtensionControlFile *control,
 
 	/* Find shortest path */
 	result = find_update_path(evi_list, evi_start, evi_target, false, false);
+
+	/* Before we report an ERROR, try to download a remote extension */
+	if (result == NIL && download_extension_file_hook && !attempted_download)
+	{
+		attempted_download = true;
+		download_extension_file_hook(control->name, false);
+
+		/* Try again to find the shortest path */
+		goto reidentify;
+	}
 
 	if (result == NIL)
 		ereport(ERROR,


### PR DESCRIPTION
Previously, remote extensions were not fetched unless they were used in some other manner. For instance, loading a BM25 index in pg_search fetches the pg_search extension. However, if on a fresh compute the user ran `ALTER EXTENSION pg_search UPDATE TO '0.15.6'`, we would not fetch the extension and fail to find an update path.