### PR TITLE
Moving LwLSN Cache to Neon Extension v16

### DIFF
--- a/src/backend/access/gin/gininsert.c
+++ b/src/backend/access/gin/gininsert.c
@@ -421,8 +421,10 @@ ginbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 		log_newpage_range(index, MAIN_FORKNUM,
 						  0, RelationGetNumberOfBlocks(index),
 						  true);
-		SetLastWrittenLSNForBlockRange(XactLastRecEnd, index->rd_smgr->smgr_rlocator.locator, MAIN_FORKNUM, 0, RelationGetNumberOfBlocks(index));
-		SetLastWrittenLSNForRelation(XactLastRecEnd, index->rd_smgr->smgr_rlocator.locator, MAIN_FORKNUM);
+		if (set_lwlsn_block_range_hook)
+			set_lwlsn_block_range_hook(XactLastRecEnd, index->rd_smgr->smgr_rlocator.locator, MAIN_FORKNUM, 0, RelationGetNumberOfBlocks(index));
+		if (set_lwlsn_relation_hook)
+			set_lwlsn_relation_hook(XactLastRecEnd, index->rd_smgr->smgr_rlocator.locator, MAIN_FORKNUM);
 	}
 
 	smgr_end_unlogged_build(index->rd_smgr);

--- a/src/backend/access/gist/gistbuild.c
+++ b/src/backend/access/gist/gistbuild.c
@@ -343,10 +343,12 @@ gistbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 			log_newpage_range(index, MAIN_FORKNUM,
 							  0, RelationGetNumberOfBlocks(index),
 							  true);
-			SetLastWrittenLSNForBlockRange(XactLastRecEnd,
-							  index->rd_smgr->smgr_rlocator.locator,
-							  MAIN_FORKNUM, 0, RelationGetNumberOfBlocks(index));
-			SetLastWrittenLSNForRelation(XactLastRecEnd, index->rd_smgr->smgr_rlocator.locator, MAIN_FORKNUM);
+			if (set_lwlsn_block_range_hook)
+				set_lwlsn_block_range_hook(XactLastRecEnd,
+								index->rd_smgr->smgr_rlocator.locator,
+								MAIN_FORKNUM, 0, RelationGetNumberOfBlocks(index));
+			if (set_lwlsn_relation_hook)
+				set_lwlsn_relation_hook(XactLastRecEnd, index->rd_smgr->smgr_rlocator.locator, MAIN_FORKNUM);
 		}
 
 		smgr_end_unlogged_build(index->rd_smgr);
@@ -480,9 +482,11 @@ gist_indexsortbuild(GISTBuildState *state)
 		lsn = log_newpage(&state->indexrel->rd_locator, MAIN_FORKNUM, GIST_ROOT_BLKNO,
 						  levelstate->pages[0], true);
 
-		SetLastWrittenLSNForBlock(lsn, state->indexrel->rd_smgr->smgr_rlocator.locator,
-								  MAIN_FORKNUM, GIST_ROOT_BLKNO);
-		SetLastWrittenLSNForRelation(lsn, state->indexrel->rd_smgr->smgr_rlocator.locator, MAIN_FORKNUM);
+		if (set_lwlsn_block_hook)
+			set_lwlsn_block_hook(lsn, state->indexrel->rd_smgr->smgr_rlocator.locator,
+									MAIN_FORKNUM, GIST_ROOT_BLKNO);
+		if (set_lwlsn_relation_hook)
+			set_lwlsn_relation_hook(lsn, state->indexrel->rd_smgr->smgr_rlocator.locator, MAIN_FORKNUM);
 	}
 
 	pfree(levelstate->pages[0]);

--- a/src/backend/access/spgist/spginsert.c
+++ b/src/backend/access/spgist/spginsert.c
@@ -144,9 +144,11 @@ spgbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 		log_newpage_range(index, MAIN_FORKNUM,
 						  0, RelationGetNumberOfBlocks(index),
 						  true);
-		SetLastWrittenLSNForBlockRange(XactLastRecEnd, index->rd_smgr->smgr_rlocator.locator,
-						  MAIN_FORKNUM, 0, RelationGetNumberOfBlocks(index));
-		SetLastWrittenLSNForRelation(XactLastRecEnd, index->rd_smgr->smgr_rlocator.locator, MAIN_FORKNUM);
+		if (set_lwlsn_block_range_hook)
+			set_lwlsn_block_range_hook(XactLastRecEnd, index->rd_smgr->smgr_rlocator.locator,
+							MAIN_FORKNUM, 0, RelationGetNumberOfBlocks(index));
+		if (set_lwlsn_relation_hook)
+			set_lwlsn_relation_hook(XactLastRecEnd, index->rd_smgr->smgr_rlocator.locator, MAIN_FORKNUM);
 	}
 
 	smgr_end_unlogged_build(index->rd_smgr);

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6296,7 +6296,7 @@ SetLastWrittenLSNForBlock(XLogRecPtr lsn, RelFileLocator rlocator, ForkNumber fo
 XLogRecPtr
 SetLastWrittenLSNForRelation(XLogRecPtr lsn, RelFileLocator rlocator, ForkNumber forknum)
 {
-	if (set_lwlsn_block_range_hook)
+	if (set_lwlsn_block_hook)
 	{
 		return set_lwlsn_block_hook(lsn, rlocator, forknum, REL_METADATA_PSEUDO_BLOCKNO);
 	}
@@ -6310,7 +6310,7 @@ XLogRecPtr
 SetLastWrittenLSNForDatabase(XLogRecPtr lsn)
 {
 	RelFileLocator dummyNode = {InvalidOid, InvalidOid, InvalidOid};
-	if (set_lwlsn_block_range_hook)
+	if (set_lwlsn_block_hook)
 	{
 		return set_lwlsn_block_hook(lsn, dummyNode, MAIN_FORKNUM, 0);
 	}

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -5143,6 +5143,8 @@ readZenithSignalFile(void)
 	}
 }
 
+update_max_lwlsn_hook_type update_max_lwlsn_hook = NULL;
+
 /*
  * This must be called ONCE during postmaster or standalone-backend startup
  */
@@ -5410,6 +5412,10 @@ StartupXLOG(void)
 
 	RedoRecPtr = XLogCtl->RedoRecPtr = XLogCtl->Insert.RedoRecPtr = checkPoint.redo;
 	doPageWrites = lastFullPageWrites;
+
+	if (update_max_lwlsn_hook) {
+		update_max_lwlsn_hook(RedoRecPtr);
+	}
 
 	/* REDO */
 	if (InRecovery)

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -151,6 +151,12 @@ int			wal_segment_size = DEFAULT_XLOG_SEG_SIZE;
 /* NEON: Hook to allow the neon extension to restore running-xacts from CLOG at replica startup */
 restore_running_xacts_callback_t restore_running_xacts_callback;
 
+/* NEON: Hook Definitions that enabled the moving of LastWrittenLSN Cache to the neon extension*/
+update_max_lwlsn_hook_type update_max_lwlsn_hook = NULL;
+set_lwlsn_block_range_hook_type set_lwlsn_block_range_hook = NULL;
+set_lwlsn_block_v_hook_type set_lwlsn_block_v_hook = NULL;
+set_lwlsn_block_hook_type set_lwlsn_block_hook = NULL;
+
 /*
  * Number of WAL insertion locks to use. A higher value allows more insertions
  * to happen concurrently, but adds some CPU overhead to flushing the WAL,
@@ -4509,7 +4515,7 @@ GetActiveWalLevelOnStandby(void)
 	return ControlFile->wal_level;
 }
 
-static Size
+Size
 XLOGCtlShmemSize(void)
 {
 	Size		size;
@@ -4557,15 +4563,6 @@ XLOGCtlShmemSize(void)
 	 */
 
 	return size;
-}
-
-/*
- * Initialization of shared memory for XLOG
- */
-Size
-XLOGShmemSize(void)
-{
-	return XLOGCtlShmemSize();
 }
 
 void
@@ -5143,8 +5140,6 @@ readZenithSignalFile(void)
 	}
 }
 
-update_max_lwlsn_hook_type update_max_lwlsn_hook = NULL;
-
 /*
  * This must be called ONCE during postmaster or standalone-backend startup
  */
@@ -5413,9 +5408,9 @@ StartupXLOG(void)
 	RedoRecPtr = XLogCtl->RedoRecPtr = XLogCtl->Insert.RedoRecPtr = checkPoint.redo;
 	doPageWrites = lastFullPageWrites;
 
-	if (update_max_lwlsn_hook) {
+	if (update_max_lwlsn_hook)
 		update_max_lwlsn_hook(RedoRecPtr);
-	}
+	
 
 	/* REDO */
 	if (InRecovery)
@@ -6254,10 +6249,6 @@ GetInsertRecPtr(void)
 	return recptr;
 }
 
-set_lwlsn_block_range_hook_type set_lwlsn_block_range_hook = NULL;
-set_lwlsn_block_v_hook_type set_lwlsn_block_v_hook = NULL;
-set_lwlsn_block_hook_type set_lwlsn_block_hook = NULL;
-
 /*
  * SetLastWrittenLSNForBlockRange -- Set maximal LSN of written page range.
  * We maintain cache of last written LSNs with limited size and LRU replacement
@@ -6272,9 +6263,8 @@ XLogRecPtr
 SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileLocator rlocator, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks)
 {
 	if (set_lwlsn_block_range_hook)
-	{
 		return set_lwlsn_block_range_hook(lsn, rlocator, forknum, from, n_blocks);
-	}
+	
 	return lsn;
 }
 
@@ -6285,9 +6275,8 @@ XLogRecPtr
 SetLastWrittenLSNForBlock(XLogRecPtr lsn, RelFileLocator rlocator, ForkNumber forknum, BlockNumber blkno)
 {
 	if (set_lwlsn_block_range_hook)
-	{
 		return set_lwlsn_block_range_hook(lsn, rlocator, forknum, blkno, 1);
-	}
+
 	return lsn;
 }
 

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -141,7 +141,6 @@ int			max_slot_wal_keep_size_mb = -1;
 int			wal_decode_buffer_size = 512 * 1024;
 bool		track_wal_io_timing = false;
 uint64		predefined_sysidentifier;
-int			lastWrittenLsnCacheSize;
 
 #ifdef WAL_DEBUG
 bool		XLOG_DEBUG = false;
@@ -211,24 +210,6 @@ const struct config_enum_entry archive_mode_options[] = {
 	{NULL, 0, false}
 };
 
-typedef struct LastWrittenLsnCacheEntry
-{
-	BufferTag	key;
-	XLogRecPtr	lsn;
-	/* double linked list for LRU replacement algorithm */
-	dlist_node	lru_node;
-} LastWrittenLsnCacheEntry;
-
-
-/*
- * Cache of last written LSN for each relation page.
- * Also to provide request LSN for smgrnblocks, smgrexists there is pseudokey=InvalidBlockId which stores LSN of last
- * relation metadata update.
- * Size of the cache is limited by GUC variable lastWrittenLsnCacheSize ("lsn_cache_size"),
- * pages are replaced using LRU algorithm, based on L2-list.
- * Access to this cache is protected by 'LastWrittenLsnLock'.
- */
-static HTAB *lastWrittenLsnCache;
 
 /*
  * Statistics for current checkpoint are collected in this global struct.
@@ -581,17 +562,6 @@ typedef struct XLogCtlData
 	 * XLOG_FPW_CHANGE record that instructs full_page_writes is disabled.
 	 */
 	XLogRecPtr	lastFpwDisableRecPtr;
-
-	/*
-	 * Maximal last written LSN for pages not present in lastWrittenLsnCache
-	 */
-	XLogRecPtr  maxLastWrittenLsn;
-
-	/*
-	 * Double linked list to implement LRU replacement policy for last written LSN cache.
-	 * Access to this list as well as to last written LSN cache is protected by 'LastWrittenLsnLock'.
-	 */
-	dlist_head lastWrittenLsnLRU;
 
 	/* neon: copy of startup's RedoStartLSN for walproposer's use */
 	XLogRecPtr	RedoStartLSN;
@@ -4595,8 +4565,7 @@ XLOGCtlShmemSize(void)
 Size
 XLOGShmemSize(void)
 {
-	return XLOGCtlShmemSize() +
-		hash_estimate_size(lastWrittenLsnCacheSize, sizeof(LastWrittenLsnCacheEntry));
+	return XLOGCtlShmemSize();
 }
 
 void
@@ -4627,17 +4596,6 @@ XLOGShmemInit(void)
 
 	XLogCtl = (XLogCtlData *)
 		ShmemInitStruct("XLOG Ctl", XLOGCtlShmemSize(), &foundXLog);
-
-	if (lastWrittenLsnCacheSize > 0)
-	{
-		static HASHCTL info;
-		info.keysize = sizeof(BufferTag);
-		info.entrysize = sizeof(LastWrittenLsnCacheEntry);
-		lastWrittenLsnCache = ShmemInitHash("last_written_lsn_cache",
-											lastWrittenLsnCacheSize, lastWrittenLsnCacheSize,
-											&info,
-											HASH_ELEM | HASH_BLOBS);
-	}
 
 	localControlFile = ControlFile;
 	ControlFile = (ControlFileData *)
@@ -5452,14 +5410,6 @@ StartupXLOG(void)
 
 	RedoRecPtr = XLogCtl->RedoRecPtr = XLogCtl->Insert.RedoRecPtr = checkPoint.redo;
 	doPageWrites = lastFullPageWrites;
-
-	/*
-	 * Setup last written lsn cache, max written LSN.
-	 * Starting from here, we could be modifying pages through REDO, which requires
-	 * the existance of maxLwLsn + LwLsn LRU.
-	 */
-	XLogCtl->maxLastWrittenLsn = RedoRecPtr;
-	dlist_init(&XLogCtl->lastWrittenLsnLRU);
 
 	/* REDO */
 	if (InRecovery)
@@ -6298,59 +6248,14 @@ GetInsertRecPtr(void)
 	return recptr;
 }
 
-/*
- * GetLastWrittenLSN -- Returns maximal LSN of written page.
- * It returns an upper bound for the last written LSN of a given page,
- * either from a cached last written LSN or a global maximum last written LSN.
- * If rnode is InvalidOid then we calculate maximum among all cached LSN and maxLastWrittenLsn.
- * If cache is large enough, iterating through all hash items may be rather expensive.
- * But GetLastWrittenLSN(InvalidOid) is used only by zenith_dbsize which is not performance critical.
- */
-XLogRecPtr
-GetLastWrittenLSN(RelFileLocator rlocator, ForkNumber forknum, BlockNumber blkno)
-{
-	XLogRecPtr lsn;
-	LastWrittenLsnCacheEntry* entry;
-
-	Assert(lastWrittenLsnCacheSize != 0);
-
-	LWLockAcquire(LastWrittenLsnLock, LW_SHARED);
-
-	/* Maximal last written LSN among all non-cached pages */
-	lsn = XLogCtl->maxLastWrittenLsn;
-
-	if (rlocator.relNumber != InvalidOid)
-	{
-		BufferTag key;
-		key.spcOid = rlocator.spcOid;
-		key.dbOid = rlocator.dbOid;
-		key.relNumber = rlocator.relNumber;
-		key.forkNum = forknum;
-		key.blockNum = blkno;
-		entry = hash_search(lastWrittenLsnCache, &key, HASH_FIND, NULL);
-		if (entry != NULL)
-			lsn = entry->lsn;
-		else
-		{
-			LWLockRelease(LastWrittenLsnLock);
-			return SetLastWrittenLSNForBlock(lsn, rlocator, forknum, blkno);
-		}
-	}
-	else
-	{
-		HASH_SEQ_STATUS seq;
-		/* Find maximum of all cached LSNs */
-		hash_seq_init(&seq, lastWrittenLsnCache);
-		while ((entry = (LastWrittenLsnCacheEntry *) hash_seq_search(&seq)) != NULL)
-		{
-			if (entry->lsn > lsn)
-				lsn = entry->lsn;
-		}
-	}
-	LWLockRelease(LastWrittenLsnLock);
-
-	return lsn;
-}
+get_lwlsn_hook_type get_lwlsn_hook = NULL;
+get_lwlsn_v_hook_type get_lwlsn_v_hook = NULL;
+set_lwlsn_block_range_hook_type set_lwlsn_block_range_hook = NULL;
+set_lwlsn_block_v_hook_type set_lwlsn_block_v_hook = NULL;
+set_lwlsn_block_hook_type set_lwlsn_block_hook = NULL;
+set_lwlsn_relation_hook_type set_lwlsn_relation_hook = NULL;
+set_lwlsn_db_hook_type set_lwlsn_db_hook = NULL;
+get_lwlsn_cache_size_type get_lwlsn_cache_size = NULL;
 
 /*
  * SetLastWrittenLSNForBlockRange -- Set maximal LSN of written page range.
@@ -6365,60 +6270,10 @@ GetLastWrittenLSN(RelFileLocator rlocator, ForkNumber forknum, BlockNumber blkno
 XLogRecPtr
 SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileLocator rlocator, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks)
 {
-	if (lsn == InvalidXLogRecPtr || n_blocks == 0 || lastWrittenLsnCacheSize == 0)
-		return lsn;
-
-	LWLockAcquire(LastWrittenLsnLock, LW_EXCLUSIVE);
-	if (rlocator.relNumber == InvalidOid)
+	if (set_lwlsn_block_range_hook)
 	{
-		if (lsn > XLogCtl->maxLastWrittenLsn)
-			XLogCtl->maxLastWrittenLsn = lsn;
-		else
-			lsn = XLogCtl->maxLastWrittenLsn;
+		return set_lwlsn_block_range_hook(lsn, rlocator, forknum, from, n_blocks);
 	}
-	else
-	{
-		LastWrittenLsnCacheEntry* entry;
-		BufferTag key;
-		bool found;
-		BlockNumber i;
-
-		key.spcOid = rlocator.spcOid;
-		key.dbOid = rlocator.dbOid;
-		key.relNumber = rlocator.relNumber;
-		key.forkNum = forknum;
-		for (i = 0; i < n_blocks; i++)
-		{
-			key.blockNum = from + i;
-			entry = hash_search(lastWrittenLsnCache, &key, HASH_ENTER, &found);
-			if (found)
-			{
-				if (lsn > entry->lsn)
-					entry->lsn = lsn;
-				else
-					lsn = entry->lsn;
-				/* Unlink from LRU list */
-				dlist_delete(&entry->lru_node);
-			}
-			else
-			{
-				entry->lsn = lsn;
-				if (hash_get_num_entries(lastWrittenLsnCache) > lastWrittenLsnCacheSize)
-				{
-					/* Replace least recently used entry */
-					LastWrittenLsnCacheEntry* victim = dlist_container(LastWrittenLsnCacheEntry, lru_node, dlist_pop_head_node(&XLogCtl->lastWrittenLsnLRU));
-					/* Adjust max LSN for not cached relations/chunks if needed */
-					if (victim->lsn > XLogCtl->maxLastWrittenLsn)
-						XLogCtl->maxLastWrittenLsn = victim->lsn;
-
-					hash_search(lastWrittenLsnCache, victim, HASH_REMOVE, NULL);
-				}
-			}
-			/* Link to the end of LRU list */
-			dlist_push_tail(&XLogCtl->lastWrittenLsnLRU, &entry->lru_node);
-		}
-	}
-	LWLockRelease(LastWrittenLsnLock);
 	return lsn;
 }
 
@@ -6428,7 +6283,11 @@ SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileLocator rlocator, ForkNumb
 XLogRecPtr
 SetLastWrittenLSNForBlock(XLogRecPtr lsn, RelFileLocator rlocator, ForkNumber forknum, BlockNumber blkno)
 {
-	return SetLastWrittenLSNForBlockRange(lsn, rlocator, forknum, blkno, 1);
+	if (set_lwlsn_block_range_hook)
+	{
+		return set_lwlsn_block_range_hook(lsn, rlocator, forknum, blkno, 1);
+	}
+	return lsn;
 }
 
 /*
@@ -6437,7 +6296,11 @@ SetLastWrittenLSNForBlock(XLogRecPtr lsn, RelFileLocator rlocator, ForkNumber fo
 XLogRecPtr
 SetLastWrittenLSNForRelation(XLogRecPtr lsn, RelFileLocator rlocator, ForkNumber forknum)
 {
-	return SetLastWrittenLSNForBlock(lsn, rlocator, forknum, REL_METADATA_PSEUDO_BLOCKNO);
+	if (set_lwlsn_block_range_hook)
+	{
+		return set_lwlsn_block_hook(lsn, rlocator, forknum, REL_METADATA_PSEUDO_BLOCKNO);
+	}
+	return lsn;
 }
 
 /*
@@ -6447,7 +6310,11 @@ XLogRecPtr
 SetLastWrittenLSNForDatabase(XLogRecPtr lsn)
 {
 	RelFileLocator dummyNode = {InvalidOid, InvalidOid, InvalidOid};
-	return SetLastWrittenLSNForBlock(lsn, dummyNode, MAIN_FORKNUM, 0);
+	if (set_lwlsn_block_range_hook)
+	{
+		return set_lwlsn_block_hook(lsn, dummyNode, MAIN_FORKNUM, 0);
+	}
+	return lsn;
 }
 
 void

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -152,12 +152,12 @@ int			wal_segment_size = DEFAULT_XLOG_SEG_SIZE;
 restore_running_xacts_callback_t restore_running_xacts_callback;
 
 /* NEON: Hook Definitions that enabled the moving of LastWrittenLSN Cache to the neon extension*/
-update_max_lwlsn_hook_type update_max_lwlsn_hook = NULL;
+set_lwlsn_block_hook_type set_lwlsn_block_hook = NULL;
 set_lwlsn_block_range_hook_type set_lwlsn_block_range_hook = NULL;
 set_lwlsn_block_v_hook_type set_lwlsn_block_v_hook = NULL;
-set_lwlsn_block_hook_type set_lwlsn_block_hook = NULL;
-set_lwlsn_relation_hook_type set_lwlsn_relation_hook = NULL;
 set_lwlsn_db_hook_type set_lwlsn_db_hook = NULL;
+set_lwlsn_relation_hook_type set_lwlsn_relation_hook = NULL;
+set_max_lwlsn_hook_type set_max_lwlsn_hook = NULL;
 
 /*
  * Number of WAL insertion locks to use. A higher value allows more insertions
@@ -5410,8 +5410,8 @@ StartupXLOG(void)
 	RedoRecPtr = XLogCtl->RedoRecPtr = XLogCtl->Insert.RedoRecPtr = checkPoint.redo;
 	doPageWrites = lastFullPageWrites;
 
-	if (update_max_lwlsn_hook)
-		update_max_lwlsn_hook(RedoRecPtr);
+	if (set_max_lwlsn_hook)
+		set_max_lwlsn_hook(RedoRecPtr);
 	
 
 	/* REDO */

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6254,14 +6254,9 @@ GetInsertRecPtr(void)
 	return recptr;
 }
 
-get_lwlsn_hook_type get_lwlsn_hook = NULL;
-get_lwlsn_v_hook_type get_lwlsn_v_hook = NULL;
 set_lwlsn_block_range_hook_type set_lwlsn_block_range_hook = NULL;
 set_lwlsn_block_v_hook_type set_lwlsn_block_v_hook = NULL;
 set_lwlsn_block_hook_type set_lwlsn_block_hook = NULL;
-set_lwlsn_relation_hook_type set_lwlsn_relation_hook = NULL;
-set_lwlsn_db_hook_type set_lwlsn_db_hook = NULL;
-get_lwlsn_cache_size_type get_lwlsn_cache_size = NULL;
 
 /*
  * SetLastWrittenLSNForBlockRange -- Set maximal LSN of written page range.
@@ -6302,11 +6297,7 @@ SetLastWrittenLSNForBlock(XLogRecPtr lsn, RelFileLocator rlocator, ForkNumber fo
 XLogRecPtr
 SetLastWrittenLSNForRelation(XLogRecPtr lsn, RelFileLocator rlocator, ForkNumber forknum)
 {
-	if (set_lwlsn_block_hook)
-	{
-		return set_lwlsn_block_hook(lsn, rlocator, forknum, REL_METADATA_PSEUDO_BLOCKNO);
-	}
-	return lsn;
+	return SetLastWrittenLSNForBlock(lsn, rlocator, forknum, REL_METADATA_PSEUDO_BLOCKNO);
 }
 
 /*
@@ -6316,11 +6307,7 @@ XLogRecPtr
 SetLastWrittenLSNForDatabase(XLogRecPtr lsn)
 {
 	RelFileLocator dummyNode = {InvalidOid, InvalidOid, InvalidOid};
-	if (set_lwlsn_block_hook)
-	{
-		return set_lwlsn_block_hook(lsn, dummyNode, MAIN_FORKNUM, 0);
-	}
-	return lsn;
+	return SetLastWrittenLSNForBlock(lsn, dummyNode, MAIN_FORKNUM, 0);
 }
 
 void

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -4518,7 +4518,7 @@ GetActiveWalLevelOnStandby(void)
 }
 
 Size
-XLOGCtlShmemSize(void)
+XLOGShmemSize(void)
 {
 	Size		size;
 
@@ -4594,7 +4594,7 @@ XLOGShmemInit(void)
 
 
 	XLogCtl = (XLogCtlData *)
-		ShmemInitStruct("XLOG Ctl", XLOGCtlShmemSize(), &foundXLog);
+		ShmemInitStruct("XLOG Ctl", XLOGShmemSize(), &foundXLog);
 
 	localControlFile = ControlFile;
 	ControlFile = (ControlFileData *)

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -156,6 +156,8 @@ update_max_lwlsn_hook_type update_max_lwlsn_hook = NULL;
 set_lwlsn_block_range_hook_type set_lwlsn_block_range_hook = NULL;
 set_lwlsn_block_v_hook_type set_lwlsn_block_v_hook = NULL;
 set_lwlsn_block_hook_type set_lwlsn_block_hook = NULL;
+set_lwlsn_relation_hook_type set_lwlsn_relation_hook = NULL;
+set_lwlsn_db_hook_type set_lwlsn_db_hook = NULL;
 
 /*
  * Number of WAL insertion locks to use. A higher value allows more insertions
@@ -6247,56 +6249,6 @@ GetInsertRecPtr(void)
 	SpinLockRelease(&XLogCtl->info_lck);
 
 	return recptr;
-}
-
-/*
- * SetLastWrittenLSNForBlockRange -- Set maximal LSN of written page range.
- * We maintain cache of last written LSNs with limited size and LRU replacement
- * policy. Keeping last written LSN for each page allows to use old LSN when
- * requesting pages of unchanged or appended relations. Also it is critical for
- * efficient work of prefetch in case massive update operations (like vacuum or remove).
- *
- * rlocator.relNumber can be InvalidOid, in this case maxLastWrittenLsn is updated.
- * SetLastWrittenLsn with dummy rlocator is used by createdb and dbase_redo functions.
- */
-XLogRecPtr
-SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileLocator rlocator, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks)
-{
-	if (set_lwlsn_block_range_hook)
-		return set_lwlsn_block_range_hook(lsn, rlocator, forknum, from, n_blocks);
-	
-	return lsn;
-}
-
-/*
- * SetLastWrittenLSNForBlock -- Set maximal LSN for block
- */
-XLogRecPtr
-SetLastWrittenLSNForBlock(XLogRecPtr lsn, RelFileLocator rlocator, ForkNumber forknum, BlockNumber blkno)
-{
-	if (set_lwlsn_block_range_hook)
-		return set_lwlsn_block_range_hook(lsn, rlocator, forknum, blkno, 1);
-
-	return lsn;
-}
-
-/*
- * SetLastWrittenLSNForRelation -- Set maximal LSN for relation metadata
- */
-XLogRecPtr
-SetLastWrittenLSNForRelation(XLogRecPtr lsn, RelFileLocator rlocator, ForkNumber forknum)
-{
-	return SetLastWrittenLSNForBlock(lsn, rlocator, forknum, REL_METADATA_PSEUDO_BLOCKNO);
-}
-
-/*
- * SetLastWrittenLSNForDatabase -- Set maximal LSN for the whole database
- */
-XLogRecPtr
-SetLastWrittenLSNForDatabase(XLogRecPtr lsn)
-{
-	RelFileLocator dummyNode = {InvalidOid, InvalidOid, InvalidOid};
-	return SetLastWrittenLSNForBlock(lsn, dummyNode, MAIN_FORKNUM, 0);
 }
 
 void

--- a/src/backend/catalog/storage.c
+++ b/src/backend/catalog/storage.c
@@ -196,7 +196,8 @@ log_smgrcreate(const RelFileLocator *rlocator, ForkNumber forkNum)
 	XLogBeginInsert();
 	XLogRegisterData((char *) &xlrec, sizeof(xlrec));
 	lsn = XLogInsert(RM_SMGR_ID, XLOG_SMGR_CREATE | XLR_SPECIAL_REL_UPDATE);
-	SetLastWrittenLSNForRelation(lsn, *rlocator, forkNum);
+	if (set_lwlsn_relation_hook)
+		set_lwlsn_relation_hook(lsn, *rlocator, forkNum);
 }
 
 /*

--- a/src/backend/commands/dbcommands.c
+++ b/src/backend/commands/dbcommands.c
@@ -3287,11 +3287,8 @@ dbase_redo(XLogReaderState *record)
 		 * Make sure any future requests to the page server see the new
 		 * database.
 		 */
-		{
-			XLogRecPtr	lsn = record->EndRecPtr;
-			if (set_lwlsn_db_hook)
-				set_lwlsn_db_hook(lsn);
-		}
+		if (set_lwlsn_db_hook)
+			set_lwlsn_db_hook(record->EndRecPtr);
 
 		pfree(src_path);
 		pfree(dst_path);
@@ -3318,11 +3315,8 @@ dbase_redo(XLogReaderState *record)
 		 * Make sure any future requests to the page server see the new
 		 * database.
 		 */
-		{
-			XLogRecPtr	lsn = record->EndRecPtr;
-			if (set_lwlsn_db_hook)
-				set_lwlsn_db_hook(lsn);
-		}
+		if (set_lwlsn_db_hook)
+			set_lwlsn_db_hook(record->EndRecPtr);
 
 		pfree(dbpath);
 	}

--- a/src/backend/commands/dbcommands.c
+++ b/src/backend/commands/dbcommands.c
@@ -1464,7 +1464,8 @@ createdb(ParseState *pstate, const CreatedbStmt *stmt)
 		/*
 		 * Update global last written LSN after wal-logging create database command
 		 */
-		SetLastWrittenLSNForDatabase(XactLastRecEnd);
+		if (set_lwlsn_db_hook)
+			set_lwlsn_db_hook(XactLastRecEnd);
 
 		/*
 		 * Close pg_database, but keep lock till commit.
@@ -2131,7 +2132,8 @@ movedb(const char *dbname, const char *tblspcname)
 			lsn = XLogInsert(RM_DBASE_ID,
 							 XLOG_DBASE_CREATE_FILE_COPY | XLR_SPECIAL_REL_UPDATE);
 			// TODO: Do we really need to set the LSN here?
-			SetLastWrittenLSNForDatabase(lsn);
+			if (set_lwlsn_db_hook)
+				set_lwlsn_db_hook(lsn);
 		}
 
 		/*
@@ -3287,7 +3289,8 @@ dbase_redo(XLogReaderState *record)
 		 */
 		{
 			XLogRecPtr	lsn = record->EndRecPtr;
-			SetLastWrittenLSNForDatabase(lsn);
+			if (set_lwlsn_db_hook)
+				set_lwlsn_db_hook(lsn);
 		}
 
 		pfree(src_path);
@@ -3317,7 +3320,8 @@ dbase_redo(XLogReaderState *record)
 		 */
 		{
 			XLogRecPtr	lsn = record->EndRecPtr;
-			SetLastWrittenLSNForDatabase(lsn);
+			if (set_lwlsn_db_hook)
+				set_lwlsn_db_hook(lsn);
 		}
 
 		pfree(dbpath);

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -115,7 +115,7 @@ CalculateShmemSize(int *num_semaphores)
 	size = add_size(size, PredicateLockShmemSize());
 	size = add_size(size, ProcGlobalShmemSize());
 	size = add_size(size, XLogPrefetchShmemSize());
-	size = add_size(size, XLOGShmemSize());
+	size = add_size(size, XLOGCtlShmemSize());
 	size = add_size(size, XLogRecoveryShmemSize());
 	size = add_size(size, CLOGShmemSize());
 	size = add_size(size, CommitTsShmemSize());

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -115,7 +115,7 @@ CalculateShmemSize(int *num_semaphores)
 	size = add_size(size, PredicateLockShmemSize());
 	size = add_size(size, ProcGlobalShmemSize());
 	size = add_size(size, XLogPrefetchShmemSize());
-	size = add_size(size, XLOGCtlShmemSize());
+	size = add_size(size, XLOGShmemSize());
 	size = add_size(size, XLogRecoveryShmemSize());
 	size = add_size(size, CLOGShmemSize());
 	size = add_size(size, CommitTsShmemSize());

--- a/src/backend/utils/misc/guc_tables.c
+++ b/src/backend/utils/misc/guc_tables.c
@@ -2307,16 +2307,6 @@ struct config_int ConfigureNamesInt[] =
 	},
 
 	{
-		{"lsn_cache_size", PGC_POSTMASTER, UNGROUPED,
-			gettext_noop("Size of last written LSN cache used by Neon."),
-			NULL
-		},
-		&lastWrittenLsnCacheSize,
-		128*1024, 1024, INT_MAX,
-		NULL, NULL, NULL
-	},
-
-	{
 		{"temp_buffers", PGC_USERSET, RESOURCES_MEM,
 			gettext_noop("Sets the maximum number of temporary buffers used by each session."),
 			NULL,

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -65,7 +65,6 @@ extern PGDLLIMPORT bool track_wal_io_timing;
 extern PGDLLIMPORT int wal_decode_buffer_size;
 
 extern PGDLLIMPORT int CheckPointSegments;
-extern int  lastWrittenLsnCacheSize;
 
 
 /* Archive modes */
@@ -266,7 +265,25 @@ extern XLogRecPtr SetLastWrittenLSNForBlock(XLogRecPtr lsn, RelFileLocator relfi
 extern XLogRecPtr SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks);
 extern XLogRecPtr SetLastWrittenLSNForDatabase(XLogRecPtr lsn);
 extern XLogRecPtr SetLastWrittenLSNForRelation(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum);
-extern XLogRecPtr GetLastWrittenLSN(RelFileLocator relfilenode, ForkNumber forknum, BlockNumber blkno);
+
+/* Hooks for LwLSN */
+typedef XLogRecPtr (*get_lwlsn_hook_type)(RelFileLocator relfilenode, ForkNumber forknum, BlockNumber blkno);
+typedef void (*get_lwlsn_v_hook_type)(RelFileLocator relfilenode, ForkNumber forknum, BlockNumber blkno, int nblocks, XLogRecPtr *lsns);
+typedef XLogRecPtr (*set_lwlsn_block_range_hook_type)(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks);
+typedef XLogRecPtr (*set_lwlsn_block_v_hook_type)(const XLogRecPtr *lsns, RelFileLocator relfilenode, ForkNumber forknum, BlockNumber blockno, int nblocks);
+typedef XLogRecPtr (*set_lwlsn_block_hook_type)(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum, BlockNumber blkno);
+typedef XLogRecPtr (*set_lwlsn_relation_hook_type)(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum);
+typedef XLogRecPtr (*set_lwlsn_db_hook_type)(XLogRecPtr lsn);
+typedef int (*get_lwlsn_cache_size_type) (void);
+
+extern get_lwlsn_hook_type get_lwlsn_hook;
+extern get_lwlsn_v_hook_type get_lwlsn_v_hook;
+extern set_lwlsn_block_range_hook_type set_lwlsn_block_range_hook;
+extern set_lwlsn_block_v_hook_type set_lwlsn_block_v_hook;
+extern set_lwlsn_block_hook_type set_lwlsn_block_hook;
+extern set_lwlsn_relation_hook_type set_lwlsn_relation_hook;
+extern set_lwlsn_db_hook_type set_lwlsn_db_hook;
+extern get_lwlsn_cache_size_type get_lwlsn_cache_size;
 
 extern void SetRedoStartLsn(XLogRecPtr RedoStartLSN);
 extern XLogRecPtr GetRedoStartLsn(void);

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -275,6 +275,7 @@ typedef XLogRecPtr (*set_lwlsn_block_hook_type)(XLogRecPtr lsn, RelFileLocator r
 typedef XLogRecPtr (*set_lwlsn_relation_hook_type)(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum);
 typedef XLogRecPtr (*set_lwlsn_db_hook_type)(XLogRecPtr lsn);
 typedef int (*get_lwlsn_cache_size_type) (void);
+typedef void (*update_max_lwlsn_hook_type) (XLogRecPtr lsn);
 
 extern get_lwlsn_hook_type get_lwlsn_hook;
 extern get_lwlsn_v_hook_type get_lwlsn_v_hook;
@@ -284,6 +285,7 @@ extern set_lwlsn_block_hook_type set_lwlsn_block_hook;
 extern set_lwlsn_relation_hook_type set_lwlsn_relation_hook;
 extern set_lwlsn_db_hook_type set_lwlsn_db_hook;
 extern get_lwlsn_cache_size_type get_lwlsn_cache_size;
+extern update_max_lwlsn_hook_type update_max_lwlsn_hook;
 
 extern void SetRedoStartLsn(XLogRecPtr RedoStartLSN);
 extern XLogRecPtr GetRedoStartLsn(void);

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -267,24 +267,14 @@ extern XLogRecPtr SetLastWrittenLSNForDatabase(XLogRecPtr lsn);
 extern XLogRecPtr SetLastWrittenLSNForRelation(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum);
 
 /* Hooks for LwLSN */
-typedef XLogRecPtr (*get_lwlsn_hook_type)(RelFileLocator relfilenode, ForkNumber forknum, BlockNumber blkno);
-typedef void (*get_lwlsn_v_hook_type)(RelFileLocator relfilenode, ForkNumber forknum, BlockNumber blkno, int nblocks, XLogRecPtr *lsns);
 typedef XLogRecPtr (*set_lwlsn_block_range_hook_type)(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks);
 typedef XLogRecPtr (*set_lwlsn_block_v_hook_type)(const XLogRecPtr *lsns, RelFileLocator relfilenode, ForkNumber forknum, BlockNumber blockno, int nblocks);
 typedef XLogRecPtr (*set_lwlsn_block_hook_type)(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum, BlockNumber blkno);
-typedef XLogRecPtr (*set_lwlsn_relation_hook_type)(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum);
-typedef XLogRecPtr (*set_lwlsn_db_hook_type)(XLogRecPtr lsn);
-typedef int (*get_lwlsn_cache_size_type) (void);
 typedef void (*update_max_lwlsn_hook_type) (XLogRecPtr lsn);
 
-extern get_lwlsn_hook_type get_lwlsn_hook;
-extern get_lwlsn_v_hook_type get_lwlsn_v_hook;
 extern set_lwlsn_block_range_hook_type set_lwlsn_block_range_hook;
 extern set_lwlsn_block_v_hook_type set_lwlsn_block_v_hook;
 extern set_lwlsn_block_hook_type set_lwlsn_block_hook;
-extern set_lwlsn_relation_hook_type set_lwlsn_relation_hook;
-extern set_lwlsn_db_hook_type set_lwlsn_db_hook;
-extern get_lwlsn_cache_size_type get_lwlsn_cache_size;
 extern update_max_lwlsn_hook_type update_max_lwlsn_hook;
 
 extern void SetRedoStartLsn(XLogRecPtr RedoStartLSN);

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -261,20 +261,19 @@ extern XLogRecPtr GetLastImportantRecPtr(void);
 
 /* neon specifics */
 
-extern XLogRecPtr SetLastWrittenLSNForBlock(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum, BlockNumber blkno);
-extern XLogRecPtr SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks);
-extern XLogRecPtr SetLastWrittenLSNForDatabase(XLogRecPtr lsn);
-extern XLogRecPtr SetLastWrittenLSNForRelation(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum);
-
 /* Hooks for LwLSN */
 typedef XLogRecPtr (*set_lwlsn_block_range_hook_type)(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks);
 typedef XLogRecPtr (*set_lwlsn_block_v_hook_type)(const XLogRecPtr *lsns, RelFileLocator relfilenode, ForkNumber forknum, BlockNumber blockno, int nblocks);
 typedef XLogRecPtr (*set_lwlsn_block_hook_type)(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum, BlockNumber blkno);
+typedef XLogRecPtr (*set_lwlsn_relation_hook_type)(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum);
+typedef XLogRecPtr (*set_lwlsn_db_hook_type)(XLogRecPtr lsn);
 typedef void (*update_max_lwlsn_hook_type) (XLogRecPtr lsn);
 
 extern set_lwlsn_block_range_hook_type set_lwlsn_block_range_hook;
 extern set_lwlsn_block_v_hook_type set_lwlsn_block_v_hook;
 extern set_lwlsn_block_hook_type set_lwlsn_block_hook;
+extern set_lwlsn_relation_hook_type set_lwlsn_relation_hook;
+extern set_lwlsn_db_hook_type set_lwlsn_db_hook;
 extern update_max_lwlsn_hook_type update_max_lwlsn_hook;
 
 extern void SetRedoStartLsn(XLogRecPtr RedoStartLSN);

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -262,19 +262,19 @@ extern XLogRecPtr GetLastImportantRecPtr(void);
 /* neon specifics */
 
 /* Hooks for LwLSN */
+typedef XLogRecPtr (*set_lwlsn_block_hook_type)(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum, BlockNumber blkno);
 typedef XLogRecPtr (*set_lwlsn_block_range_hook_type)(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks);
 typedef XLogRecPtr (*set_lwlsn_block_v_hook_type)(const XLogRecPtr *lsns, RelFileLocator relfilenode, ForkNumber forknum, BlockNumber blockno, int nblocks);
-typedef XLogRecPtr (*set_lwlsn_block_hook_type)(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum, BlockNumber blkno);
-typedef XLogRecPtr (*set_lwlsn_relation_hook_type)(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum);
 typedef XLogRecPtr (*set_lwlsn_db_hook_type)(XLogRecPtr lsn);
-typedef void (*update_max_lwlsn_hook_type) (XLogRecPtr lsn);
+typedef XLogRecPtr (*set_lwlsn_relation_hook_type)(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum);
+typedef void (*set_max_lwlsn_hook_type) (XLogRecPtr lsn);
 
+extern set_lwlsn_block_hook_type set_lwlsn_block_hook;
 extern set_lwlsn_block_range_hook_type set_lwlsn_block_range_hook;
 extern set_lwlsn_block_v_hook_type set_lwlsn_block_v_hook;
-extern set_lwlsn_block_hook_type set_lwlsn_block_hook;
-extern set_lwlsn_relation_hook_type set_lwlsn_relation_hook;
 extern set_lwlsn_db_hook_type set_lwlsn_db_hook;
-extern update_max_lwlsn_hook_type update_max_lwlsn_hook;
+extern set_lwlsn_relation_hook_type set_lwlsn_relation_hook;
+extern set_max_lwlsn_hook_type set_max_lwlsn_hook;
 
 extern void SetRedoStartLsn(XLogRecPtr RedoStartLSN);
 extern XLogRecPtr GetRedoStartLsn(void);

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -238,7 +238,7 @@ extern uint64 GetSystemIdentifier(void);
 extern char *GetMockAuthenticationNonce(void);
 extern bool DataChecksumsEnabled(void);
 extern XLogRecPtr GetFakeLSNForUnloggedRel(void);
-extern Size XLOGShmemSize(void);
+extern Size XLOGCtlShmemSize(void);
 extern void XLOGShmemInit(void);
 extern void BootStrapXLOG(void);
 extern void InitializeWalConsistencyChecking(void);

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -238,7 +238,7 @@ extern uint64 GetSystemIdentifier(void);
 extern char *GetMockAuthenticationNonce(void);
 extern bool DataChecksumsEnabled(void);
 extern XLogRecPtr GetFakeLSNForUnloggedRel(void);
-extern Size XLOGCtlShmemSize(void);
+extern Size XLOGShmemSize(void);
 extern void XLOGShmemInit(void);
 extern void BootStrapXLOG(void);
 extern void InitializeWalConsistencyChecking(void);


### PR DESCRIPTION
Removing the LastWrittenLSN code from Postgres v16 as part of moving it into the neon extension to reduce code duplication.

Part of: https://github.com/neondatabase/neon/issues/10973