### PR TITLE
Moving LwLSN Cache to Neon Extension v15

### DIFF
--- a/src/backend/access/gin/gininsert.c
+++ b/src/backend/access/gin/gininsert.c
@@ -421,8 +421,10 @@ ginbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 		log_newpage_range(index, MAIN_FORKNUM,
 						  0, RelationGetNumberOfBlocks(index),
 						  true);
-		SetLastWrittenLSNForBlockRange(XactLastRecEnd, index->rd_smgr->smgr_rnode.node, MAIN_FORKNUM, 0, RelationGetNumberOfBlocks(index));
-		SetLastWrittenLSNForRelation(XactLastRecEnd, index->rd_smgr->smgr_rnode.node, MAIN_FORKNUM);
+		if (set_lwlsn_block_range_hook)
+			set_lwlsn_block_range_hook(XactLastRecEnd, index->rd_smgr->smgr_rnode.node, MAIN_FORKNUM, 0, RelationGetNumberOfBlocks(index));
+		if (set_lwlsn_relation_hook)
+			set_lwlsn_relation_hook(XactLastRecEnd, index->rd_smgr->smgr_rnode.node, MAIN_FORKNUM);
 	}
 
 	smgr_end_unlogged_build(index->rd_smgr);

--- a/src/backend/access/gist/gistbuild.c
+++ b/src/backend/access/gist/gistbuild.c
@@ -342,10 +342,12 @@ gistbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 			log_newpage_range(index, MAIN_FORKNUM,
 							  0, RelationGetNumberOfBlocks(index),
 							  true);
-			SetLastWrittenLSNForBlockRange(XactLastRecEnd,
-							  index->rd_smgr->smgr_rnode.node,
-							  MAIN_FORKNUM, 0, RelationGetNumberOfBlocks(index));
-			SetLastWrittenLSNForRelation(XactLastRecEnd, index->rd_smgr->smgr_rnode.node, MAIN_FORKNUM);
+			if (set_lwlsn_block_range_hook)
+				set_lwlsn_block_range_hook(XactLastRecEnd,
+								index->rd_smgr->smgr_rnode.node,
+								MAIN_FORKNUM, 0, RelationGetNumberOfBlocks(index));
+			if (set_lwlsn_relation_hook)
+				set_lwlsn_relation_hook(XactLastRecEnd, index->rd_smgr->smgr_rnode.node, MAIN_FORKNUM);
 		}
 		smgr_end_unlogged_build(index->rd_smgr);
 	}
@@ -477,9 +479,11 @@ gist_indexsortbuild(GISTBuildState *state)
 
 		lsn = log_newpage(&state->indexrel->rd_node, MAIN_FORKNUM, GIST_ROOT_BLKNO,
  					levelstate->pages[0], true);
-		SetLastWrittenLSNForBlock(lsn, state->indexrel->rd_smgr->smgr_rnode.node,
-								  MAIN_FORKNUM, GIST_ROOT_BLKNO);
-		SetLastWrittenLSNForRelation(lsn, state->indexrel->rd_smgr->smgr_rnode.node, MAIN_FORKNUM);
+		if (set_lwlsn_block_hook)
+			set_lwlsn_block_hook(lsn, state->indexrel->rd_smgr->smgr_rnode.node,
+									MAIN_FORKNUM, GIST_ROOT_BLKNO);
+		if (set_lwlsn_relation_hook)
+			set_lwlsn_relation_hook(lsn, state->indexrel->rd_smgr->smgr_rnode.node, MAIN_FORKNUM);
 	}
 
 	pfree(levelstate->pages[0]);

--- a/src/backend/access/spgist/spginsert.c
+++ b/src/backend/access/spgist/spginsert.c
@@ -144,9 +144,11 @@ spgbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 		log_newpage_range(index, MAIN_FORKNUM,
 						  0, RelationGetNumberOfBlocks(index),
 						  true);
-		SetLastWrittenLSNForBlockRange(XactLastRecEnd, index->rd_smgr->smgr_rnode.node,
-						  MAIN_FORKNUM, 0, RelationGetNumberOfBlocks(index));
-		SetLastWrittenLSNForRelation(XactLastRecEnd, index->rd_smgr->smgr_rnode.node, MAIN_FORKNUM);
+		if (set_lwlsn_block_range_hook)
+			set_lwlsn_block_range_hook(XactLastRecEnd, index->rd_smgr->smgr_rnode.node,
+							MAIN_FORKNUM, 0, RelationGetNumberOfBlocks(index));
+		if (set_lwlsn_relation_hook)
+			set_lwlsn_relation_hook(XactLastRecEnd, index->rd_smgr->smgr_rnode.node, MAIN_FORKNUM);
 	}
 
 	smgr_end_unlogged_build(index->rd_smgr);

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -149,6 +149,12 @@ int			wal_segment_size = DEFAULT_XLOG_SEG_SIZE;
 /* NEON: Hook to allow the neon extension to restore running-xacts from CLOG at replica startup */
 restore_running_xacts_callback_t restore_running_xacts_callback;
 
+/* NEON: Hook Definitions that enabled the moving of LastWrittenLSN Cache to the neon extension*/
+update_max_lwlsn_hook_type update_max_lwlsn_hook = NULL;
+set_lwlsn_block_range_hook_type set_lwlsn_block_range_hook = NULL;
+set_lwlsn_block_v_hook_type set_lwlsn_block_v_hook = NULL;
+set_lwlsn_block_hook_type set_lwlsn_block_hook = NULL;
+
 /*
  * Number of WAL insertion locks to use. A higher value allows more insertions
  * to happen concurrently, but adds some CPU overhead to flushing the WAL,
@@ -4354,7 +4360,7 @@ LocalProcessControlFile(bool reset)
 	ReadControlFile();
 }
 
-static Size
+Size
 XLOGCtlShmemSize(void)
 {
 	Size		size;
@@ -4402,15 +4408,6 @@ XLOGCtlShmemSize(void)
 	 */
 
 	return size;
-}
-
-/*
- * Initialization of shared memory for XLOG
- */
-Size
-XLOGShmemSize(void)
-{
-	return XLOGCtlShmemSize();
 }
 
 void
@@ -4991,8 +4988,6 @@ readZenithSignalFile(void)
 	}
 }
 
-update_max_lwlsn_hook_type update_max_lwlsn_hook = NULL;
-
 /*
  * This must be called ONCE during postmaster or standalone-backend startup
  */
@@ -5261,9 +5256,8 @@ StartupXLOG(void)
 	RedoRecPtr = XLogCtl->RedoRecPtr = XLogCtl->Insert.RedoRecPtr = checkPoint.redo;
 	doPageWrites = lastFullPageWrites;
 
-	if (update_max_lwlsn_hook) {
+	if (update_max_lwlsn_hook)
 		update_max_lwlsn_hook(RedoRecPtr);
-	}
 
 	/* REDO */
 	if (InRecovery)
@@ -6104,10 +6098,6 @@ GetInsertRecPtr(void)
 	return recptr;
 }
 
-set_lwlsn_block_range_hook_type set_lwlsn_block_range_hook = NULL;
-set_lwlsn_block_v_hook_type set_lwlsn_block_v_hook = NULL;
-set_lwlsn_block_hook_type set_lwlsn_block_hook = NULL;
-
 /*
  * SetLastWrittenLSNForBlockRange -- Set maximal LSN of written page range.
  * We maintain cache of last written LSNs with limited size and LRU replacement
@@ -6122,9 +6112,8 @@ XLogRecPtr
 SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileNode rnode, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks)
 {
 	if (set_lwlsn_block_range_hook)
-	{
 		return set_lwlsn_block_range_hook(lsn, rnode, forknum, from, n_blocks);
-	}
+
 	return lsn;
 }
 
@@ -6135,9 +6124,8 @@ XLogRecPtr
 SetLastWrittenLSNForBlock(XLogRecPtr lsn, RelFileNode rnode, ForkNumber forknum, BlockNumber blkno)
 {
 	if (set_lwlsn_block_range_hook)
-	{
 		return set_lwlsn_block_range_hook(lsn, rnode, forknum, blkno, 1);
-	}
+
 	return lsn;
 }
 

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -4363,7 +4363,7 @@ LocalProcessControlFile(bool reset)
 }
 
 Size
-XLOGCtlShmemSize(void)
+XLOGShmemSize(void)
 {
 	Size		size;
 
@@ -4439,7 +4439,7 @@ XLOGShmemInit(void)
 
 
 	XLogCtl = (XLogCtlData *)
-		ShmemInitStruct("XLOG Ctl", XLOGCtlShmemSize(), &foundXLog);
+		ShmemInitStruct("XLOG Ctl", XLOGShmemSize(), &foundXLog);
 
 	localControlFile = ControlFile;
 	ControlFile = (ControlFileData *)

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -150,12 +150,12 @@ int			wal_segment_size = DEFAULT_XLOG_SEG_SIZE;
 restore_running_xacts_callback_t restore_running_xacts_callback;
 
 /* NEON: Hook Definitions that enabled the moving of LastWrittenLSN Cache to the neon extension*/
-update_max_lwlsn_hook_type update_max_lwlsn_hook = NULL;
+set_lwlsn_block_hook_type set_lwlsn_block_hook = NULL;
 set_lwlsn_block_range_hook_type set_lwlsn_block_range_hook = NULL;
 set_lwlsn_block_v_hook_type set_lwlsn_block_v_hook = NULL;
-set_lwlsn_block_hook_type set_lwlsn_block_hook = NULL;
-set_lwlsn_relation_hook_type set_lwlsn_relation_hook = NULL;
 set_lwlsn_db_hook_type set_lwlsn_db_hook = NULL;
+set_lwlsn_relation_hook_type set_lwlsn_relation_hook = NULL;
+set_max_lwlsn_hook_type set_max_lwlsn_hook = NULL;
 
 /*
  * Number of WAL insertion locks to use. A higher value allows more insertions
@@ -5258,8 +5258,8 @@ StartupXLOG(void)
 	RedoRecPtr = XLogCtl->RedoRecPtr = XLogCtl->Insert.RedoRecPtr = checkPoint.redo;
 	doPageWrites = lastFullPageWrites;
 
-	if (update_max_lwlsn_hook)
-		update_max_lwlsn_hook(RedoRecPtr);
+	if (set_max_lwlsn_hook)
+		set_max_lwlsn_hook(RedoRecPtr);
 
 	/* REDO */
 	if (InRecovery)

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6104,14 +6104,9 @@ GetInsertRecPtr(void)
 	return recptr;
 }
 
-get_lwlsn_hook_type get_lwlsn_hook = NULL;
-get_lwlsn_v_hook_type get_lwlsn_v_hook = NULL;
 set_lwlsn_block_range_hook_type set_lwlsn_block_range_hook = NULL;
 set_lwlsn_block_v_hook_type set_lwlsn_block_v_hook = NULL;
 set_lwlsn_block_hook_type set_lwlsn_block_hook = NULL;
-set_lwlsn_relation_hook_type set_lwlsn_relation_hook = NULL;
-set_lwlsn_db_hook_type set_lwlsn_db_hook = NULL;
-get_lwlsn_cache_size_type get_lwlsn_cache_size = NULL;
 
 /*
  * SetLastWrittenLSNForBlockRange -- Set maximal LSN of written page range.
@@ -6152,11 +6147,7 @@ SetLastWrittenLSNForBlock(XLogRecPtr lsn, RelFileNode rnode, ForkNumber forknum,
 XLogRecPtr
 SetLastWrittenLSNForRelation(XLogRecPtr lsn, RelFileNode rnode, ForkNumber forknum)
 {
-	if (set_lwlsn_block_hook)
-	{
-		return set_lwlsn_block_hook(lsn, rnode, forknum, REL_METADATA_PSEUDO_BLOCKNO);
-	}
-	return lsn;
+	return SetLastWrittenLSNForBlock(lsn, rnode, forknum, REL_METADATA_PSEUDO_BLOCKNO);
 }
 
 /*
@@ -6166,11 +6157,7 @@ XLogRecPtr
 SetLastWrittenLSNForDatabase(XLogRecPtr lsn)
 {
 	RelFileNode dummyNode = {InvalidOid, InvalidOid, InvalidOid};
-	if (set_lwlsn_block_hook)
-	{
-		return set_lwlsn_block_hook(lsn, dummyNode, MAIN_FORKNUM, 0);
-	}
-	return lsn;
+	return SetLastWrittenLSNForBlock(lsn, dummyNode, MAIN_FORKNUM, 0);
 }
 
 void

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -4991,6 +4991,8 @@ readZenithSignalFile(void)
 	}
 }
 
+update_max_lwlsn_hook_type update_max_lwlsn_hook = NULL;
+
 /*
  * This must be called ONCE during postmaster or standalone-backend startup
  */
@@ -5258,6 +5260,10 @@ StartupXLOG(void)
 
 	RedoRecPtr = XLogCtl->RedoRecPtr = XLogCtl->Insert.RedoRecPtr = checkPoint.redo;
 	doPageWrites = lastFullPageWrites;
+
+	if (update_max_lwlsn_hook) {
+		update_max_lwlsn_hook(RedoRecPtr);
+	}
 
 	/* REDO */
 	if (InRecovery)

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -154,6 +154,8 @@ update_max_lwlsn_hook_type update_max_lwlsn_hook = NULL;
 set_lwlsn_block_range_hook_type set_lwlsn_block_range_hook = NULL;
 set_lwlsn_block_v_hook_type set_lwlsn_block_v_hook = NULL;
 set_lwlsn_block_hook_type set_lwlsn_block_hook = NULL;
+set_lwlsn_relation_hook_type set_lwlsn_relation_hook = NULL;
+set_lwlsn_db_hook_type set_lwlsn_db_hook = NULL;
 
 /*
  * Number of WAL insertion locks to use. A higher value allows more insertions
@@ -6096,56 +6098,6 @@ GetInsertRecPtr(void)
 	SpinLockRelease(&XLogCtl->info_lck);
 
 	return recptr;
-}
-
-/*
- * SetLastWrittenLSNForBlockRange -- Set maximal LSN of written page range.
- * We maintain cache of last written LSNs with limited size and LRU replacement
- * policy. Keeping last written LSN for each page allows to use old LSN when
- * requesting pages of unchanged or appended relations. Also it is critical for
- * efficient work of prefetch in case massive update operations (like vacuum or remove).
- *
- * rnode.relNode can be InvalidOid, in this case maxLastWrittenLsn is updated.
- * SetLastWrittenLsn with dummy rnode is used by createdb and dbase_redo functions.
- */
-XLogRecPtr
-SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileNode rnode, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks)
-{
-	if (set_lwlsn_block_range_hook)
-		return set_lwlsn_block_range_hook(lsn, rnode, forknum, from, n_blocks);
-
-	return lsn;
-}
-
-/*
- * SetLastWrittenLSNForBlock -- Set maximal LSN for block
- */
-XLogRecPtr
-SetLastWrittenLSNForBlock(XLogRecPtr lsn, RelFileNode rnode, ForkNumber forknum, BlockNumber blkno)
-{
-	if (set_lwlsn_block_range_hook)
-		return set_lwlsn_block_range_hook(lsn, rnode, forknum, blkno, 1);
-
-	return lsn;
-}
-
-/*
- * SetLastWrittenLSNForRelation -- Set maximal LSN for relation metadata
- */
-XLogRecPtr
-SetLastWrittenLSNForRelation(XLogRecPtr lsn, RelFileNode rnode, ForkNumber forknum)
-{
-	return SetLastWrittenLSNForBlock(lsn, rnode, forknum, REL_METADATA_PSEUDO_BLOCKNO);
-}
-
-/*
- * SetLastWrittenLSNForDatabase -- Set maximal LSN for the whole database
- */
-XLogRecPtr
-SetLastWrittenLSNForDatabase(XLogRecPtr lsn)
-{
-	RelFileNode dummyNode = {InvalidOid, InvalidOid, InvalidOid};
-	return SetLastWrittenLSNForBlock(lsn, dummyNode, MAIN_FORKNUM, 0);
 }
 
 void

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -139,7 +139,6 @@ int			max_slot_wal_keep_size_mb = -1;
 int			wal_decode_buffer_size = 512 * 1024;
 bool		track_wal_io_timing = false;
 uint64      predefined_sysidentifier;
-int			lastWrittenLsnCacheSize;
 
 #ifdef WAL_DEBUG
 bool		XLOG_DEBUG = false;
@@ -204,25 +203,6 @@ const struct config_enum_entry archive_mode_options[] = {
 	{"0", ARCHIVE_MODE_OFF, true},
 	{NULL, 0, false}
 };
-
-typedef struct LastWrittenLsnCacheEntry
-{
-	BufferTag	key;
-	XLogRecPtr	lsn;
-	/* double linked list for LRU replacement algorithm */
-	dlist_node	lru_node;
-} LastWrittenLsnCacheEntry;
-
-
-/*
- * Cache of last written LSN for each relation page.
- * Also to provide request LSN for smgrnblocks, smgrexists there is pseudokey=InvalidBlockId which stores LSN of last
- * relation metadata update.
- * Size of the cache is limited by GUC variable lastWrittenLsnCacheSize ("lsn_cache_size"),
- * pages are replaced using LRU algorithm, based on L2-list.
- * Access to this cache is protected by 'LastWrittenLsnLock'.
- */
-static HTAB *lastWrittenLsnCache;
 
 /*
  * Statistics for current checkpoint are collected in this global struct.
@@ -577,17 +557,6 @@ typedef struct XLogCtlData
 	 * XLOG_FPW_CHANGE record that instructs full_page_writes is disabled.
 	 */
 	XLogRecPtr	lastFpwDisableRecPtr;
-
-	/*
-	 * Maximal last written LSN for pages not present in lastWrittenLsnCache
-	 */
-	XLogRecPtr  maxLastWrittenLsn;
-
-	/*
-	 * Double linked list to implement LRU replacement policy for last written LSN cache.
-	 * Access to this list as well as to last written LSN cache is protected by 'LastWrittenLsnLock'.
-	 */
-	dlist_head lastWrittenLsnLRU;
 
 	/* neon: copy of startup's RedoStartLSN for walproposer's use */
 	XLogRecPtr	RedoStartLSN;
@@ -4441,8 +4410,7 @@ XLOGCtlShmemSize(void)
 Size
 XLOGShmemSize(void)
 {
-	return XLOGCtlShmemSize() +
-		hash_estimate_size(lastWrittenLsnCacheSize, sizeof(LastWrittenLsnCacheEntry));
+	return XLOGCtlShmemSize();
 }
 
 void
@@ -4473,17 +4441,6 @@ XLOGShmemInit(void)
 
 	XLogCtl = (XLogCtlData *)
 		ShmemInitStruct("XLOG Ctl", XLOGCtlShmemSize(), &foundXLog);
-
-	if (lastWrittenLsnCacheSize > 0)
-	{
-		static HASHCTL info;
-		info.keysize = sizeof(BufferTag);
-		info.entrysize = sizeof(LastWrittenLsnCacheEntry);
-		lastWrittenLsnCache = ShmemInitHash("last_written_lsn_cache",
-											lastWrittenLsnCacheSize, lastWrittenLsnCacheSize,
-											&info,
-											HASH_ELEM | HASH_BLOBS);
-	}
 
 	localControlFile = ControlFile;
 	ControlFile = (ControlFileData *)
@@ -5301,14 +5258,6 @@ StartupXLOG(void)
 
 	RedoRecPtr = XLogCtl->RedoRecPtr = XLogCtl->Insert.RedoRecPtr = checkPoint.redo;
 	doPageWrites = lastFullPageWrites;
-
-	/*
-	 * Setup last written lsn cache, max written LSN.
-	 * Starting from here, we could be modifying pages through REDO, which requires
-	 * the existance of maxLwLsn + LwLsn LRU.
-	 */
-	XLogCtl->maxLastWrittenLsn = RedoRecPtr;
-	dlist_init(&XLogCtl->lastWrittenLsnLRU);
 
 	/* REDO */
 	if (InRecovery)
@@ -6149,57 +6098,14 @@ GetInsertRecPtr(void)
 	return recptr;
 }
 
-/*
- * GetLastWrittenLSN -- Returns maximal LSN of written page.
- * It returns an upper bound for the last written LSN of a given page,
- * either from a cached last written LSN or a global maximum last written LSN.
- * If rnode is InvalidOid then we calculate maximum among all cached LSN and maxLastWrittenLsn.
- * If cache is large enough, iterating through all hash items may be rather expensive.
- * But GetLastWrittenLSN(InvalidOid) is used only by zenith_dbsize which is not performance critical.
- */
-XLogRecPtr
-GetLastWrittenLSN(RelFileNode rnode, ForkNumber forknum, BlockNumber blkno)
-{
-	XLogRecPtr lsn;
-	LastWrittenLsnCacheEntry* entry;
-
-	Assert(lastWrittenLsnCacheSize != 0);
-
-	LWLockAcquire(LastWrittenLsnLock, LW_SHARED);
-
-	/* Maximal last written LSN among all non-cached pages */
-	lsn = XLogCtl->maxLastWrittenLsn;
-
-	if (rnode.relNode != InvalidOid)
-	{
-		BufferTag key;
-		key.rnode = rnode;
-		key.forkNum = forknum;
-		key.blockNum = blkno;
-		entry = hash_search(lastWrittenLsnCache, &key, HASH_FIND, NULL);
-		if (entry != NULL)
-			lsn = entry->lsn;
-		else
-		{
-			LWLockRelease(LastWrittenLsnLock);
-			return SetLastWrittenLSNForBlock(lsn, rnode, forknum, blkno);
-		}
-	}
-	else
-	{
-		HASH_SEQ_STATUS seq;
-		/* Find maximum of all cached LSNs */
-		hash_seq_init(&seq, lastWrittenLsnCache);
-		while ((entry = (LastWrittenLsnCacheEntry *) hash_seq_search(&seq)) != NULL)
-		{
-			if (entry->lsn > lsn)
-				lsn = entry->lsn;
-		}
-	}
-	LWLockRelease(LastWrittenLsnLock);
-
-	return lsn;
-}
+get_lwlsn_hook_type get_lwlsn_hook = NULL;
+get_lwlsn_v_hook_type get_lwlsn_v_hook = NULL;
+set_lwlsn_block_range_hook_type set_lwlsn_block_range_hook = NULL;
+set_lwlsn_block_v_hook_type set_lwlsn_block_v_hook = NULL;
+set_lwlsn_block_hook_type set_lwlsn_block_hook = NULL;
+set_lwlsn_relation_hook_type set_lwlsn_relation_hook = NULL;
+set_lwlsn_db_hook_type set_lwlsn_db_hook = NULL;
+get_lwlsn_cache_size_type get_lwlsn_cache_size = NULL;
 
 /*
  * SetLastWrittenLSNForBlockRange -- Set maximal LSN of written page range.
@@ -6214,58 +6120,10 @@ GetLastWrittenLSN(RelFileNode rnode, ForkNumber forknum, BlockNumber blkno)
 XLogRecPtr
 SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileNode rnode, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks)
 {
-	if (lsn == InvalidXLogRecPtr || n_blocks == 0 || lastWrittenLsnCacheSize == 0)
-		return lsn;
-
-	LWLockAcquire(LastWrittenLsnLock, LW_EXCLUSIVE);
-	if (rnode.relNode == InvalidOid)
+	if (set_lwlsn_block_range_hook)
 	{
-		if (lsn > XLogCtl->maxLastWrittenLsn)
-			XLogCtl->maxLastWrittenLsn = lsn;
-		else
-			lsn = XLogCtl->maxLastWrittenLsn;
+		return set_lwlsn_block_range_hook(lsn, rnode, forknum, from, n_blocks);
 	}
-	else
-	{
-		LastWrittenLsnCacheEntry* entry;
-		BufferTag key;
-		bool found;
-		BlockNumber i;
-
-		key.rnode = rnode;
-		key.forkNum = forknum;
-		for (i = 0; i < n_blocks; i++)
-		{
-			key.blockNum = from + i;
-			entry = hash_search(lastWrittenLsnCache, &key, HASH_ENTER, &found);
-			if (found)
-			{
-				if (lsn > entry->lsn)
-					entry->lsn = lsn;
-				else
-					lsn = entry->lsn;
-				/* Unlink from LRU list */
-				dlist_delete(&entry->lru_node);
-			}
-			else
-			{
-				entry->lsn = lsn;
-				if (hash_get_num_entries(lastWrittenLsnCache) > lastWrittenLsnCacheSize)
-				{
-					/* Replace least recently used entry */
-					LastWrittenLsnCacheEntry* victim = dlist_container(LastWrittenLsnCacheEntry, lru_node, dlist_pop_head_node(&XLogCtl->lastWrittenLsnLRU));
-					/* Adjust max LSN for not cached relations/chunks if needed */
-					if (victim->lsn > XLogCtl->maxLastWrittenLsn)
-						XLogCtl->maxLastWrittenLsn = victim->lsn;
-
-					hash_search(lastWrittenLsnCache, victim, HASH_REMOVE, NULL);
-				}
-			}
-			/* Link to the end of LRU list */
-			dlist_push_tail(&XLogCtl->lastWrittenLsnLRU, &entry->lru_node);
-		}
-	}
-	LWLockRelease(LastWrittenLsnLock);
 	return lsn;
 }
 
@@ -6275,7 +6133,11 @@ SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileNode rnode, ForkNumber for
 XLogRecPtr
 SetLastWrittenLSNForBlock(XLogRecPtr lsn, RelFileNode rnode, ForkNumber forknum, BlockNumber blkno)
 {
-	return SetLastWrittenLSNForBlockRange(lsn, rnode, forknum, blkno, 1);
+	if (set_lwlsn_block_range_hook)
+	{
+		return set_lwlsn_block_range_hook(lsn, rnode, forknum, blkno, 1);
+	}
+	return lsn;
 }
 
 /*
@@ -6284,7 +6146,11 @@ SetLastWrittenLSNForBlock(XLogRecPtr lsn, RelFileNode rnode, ForkNumber forknum,
 XLogRecPtr
 SetLastWrittenLSNForRelation(XLogRecPtr lsn, RelFileNode rnode, ForkNumber forknum)
 {
-	return SetLastWrittenLSNForBlock(lsn, rnode, forknum, REL_METADATA_PSEUDO_BLOCKNO);
+	if (set_lwlsn_block_hook)
+	{
+		return set_lwlsn_block_hook(lsn, rnode, forknum, REL_METADATA_PSEUDO_BLOCKNO);
+	}
+	return lsn;
 }
 
 /*
@@ -6294,7 +6160,11 @@ XLogRecPtr
 SetLastWrittenLSNForDatabase(XLogRecPtr lsn)
 {
 	RelFileNode dummyNode = {InvalidOid, InvalidOid, InvalidOid};
-	return SetLastWrittenLSNForBlock(lsn, dummyNode, MAIN_FORKNUM, 0);
+	if (set_lwlsn_block_hook)
+	{
+		return set_lwlsn_block_hook(lsn, dummyNode, MAIN_FORKNUM, 0);
+	}
+	return lsn;
 }
 
 void

--- a/src/backend/catalog/storage.c
+++ b/src/backend/catalog/storage.c
@@ -196,7 +196,8 @@ log_smgrcreate(const RelFileNode *rnode, ForkNumber forkNum)
 	XLogBeginInsert();
 	XLogRegisterData((char *) &xlrec, sizeof(xlrec));
 	lsn = XLogInsert(RM_SMGR_ID, XLOG_SMGR_CREATE | XLR_SPECIAL_REL_UPDATE);
-	SetLastWrittenLSNForRelation(lsn, *rnode, forkNum);
+	if (set_lwlsn_relation_hook)
+		set_lwlsn_relation_hook(lsn, *rnode, forkNum);
 }
 
 /*

--- a/src/backend/commands/dbcommands.c
+++ b/src/backend/commands/dbcommands.c
@@ -3231,11 +3231,8 @@ dbase_redo(XLogReaderState *record)
 		 * Make sure any future requests to the page server see the new
 		 * database.
 		 */
-		{
-			XLogRecPtr	lsn = record->EndRecPtr;
-			if (set_lwlsn_db_hook)
-				set_lwlsn_db_hook(lsn);
-		}
+		if (set_lwlsn_db_hook)
+			set_lwlsn_db_hook(record->EndRecPtr);
 
 		pfree(src_path);
 		pfree(dst_path);
@@ -3262,11 +3259,9 @@ dbase_redo(XLogReaderState *record)
 		 * Make sure any future requests to the page server see the new
 		 * database.
 		 */
-		{
-			XLogRecPtr	lsn = record->EndRecPtr;
-			if (set_lwlsn_db_hook)
-				set_lwlsn_db_hook(lsn);
-		}
+		if (set_lwlsn_db_hook)
+			set_lwlsn_db_hook(record->EndRecPtr);
+			
 	}
 	else if (info == XLOG_DBASE_DROP)
 	{

--- a/src/backend/commands/dbcommands.c
+++ b/src/backend/commands/dbcommands.c
@@ -1401,7 +1401,8 @@ createdb(ParseState *pstate, const CreatedbStmt *stmt)
 		/*
 		 * Update global last written LSN after wal-logging create database command
 		 */
-		SetLastWrittenLSNForDatabase(XactLastRecEnd);
+		if (set_lwlsn_db_hook)
+			set_lwlsn_db_hook(XactLastRecEnd);
 
 		/*
 		 * Close pg_database, but keep lock till commit.
@@ -2067,7 +2068,8 @@ movedb(const char *dbname, const char *tblspcname)
 			lsn = XLogInsert(RM_DBASE_ID,
 							  XLOG_DBASE_CREATE_FILE_COPY | XLR_SPECIAL_REL_UPDATE);
 			// TODO: Do we really need to set the LSN here?
-			SetLastWrittenLSNForDatabase(lsn);
+			if (set_lwlsn_db_hook)
+				set_lwlsn_db_hook(lsn);
 		}
 
 		/*
@@ -3231,7 +3233,8 @@ dbase_redo(XLogReaderState *record)
 		 */
 		{
 			XLogRecPtr	lsn = record->EndRecPtr;
-			SetLastWrittenLSNForDatabase(lsn);
+			if (set_lwlsn_db_hook)
+				set_lwlsn_db_hook(lsn);
 		}
 
 		pfree(src_path);
@@ -3261,7 +3264,8 @@ dbase_redo(XLogReaderState *record)
 		 */
 		{
 			XLogRecPtr	lsn = record->EndRecPtr;
-			SetLastWrittenLSNForDatabase(lsn);
+			if (set_lwlsn_db_hook)
+				set_lwlsn_db_hook(lsn);
 		}
 	}
 	else if (info == XLOG_DBASE_DROP)

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -114,7 +114,7 @@ CalculateShmemSize(int *num_semaphores)
 	size = add_size(size, PredicateLockShmemSize());
 	size = add_size(size, ProcGlobalShmemSize());
 	size = add_size(size, XLogPrefetchShmemSize());
-	size = add_size(size, XLOGCtlShmemSize());
+	size = add_size(size, XLOGShmemSize());
 	size = add_size(size, XLogRecoveryShmemSize());
 	size = add_size(size, CLOGShmemSize());
 	size = add_size(size, CommitTsShmemSize());

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -114,7 +114,7 @@ CalculateShmemSize(int *num_semaphores)
 	size = add_size(size, PredicateLockShmemSize());
 	size = add_size(size, ProcGlobalShmemSize());
 	size = add_size(size, XLogPrefetchShmemSize());
-	size = add_size(size, XLOGShmemSize());
+	size = add_size(size, XLOGCtlShmemSize());
 	size = add_size(size, XLogRecoveryShmemSize());
 	size = add_size(size, CLOGShmemSize());
 	size = add_size(size, CommitTsShmemSize());

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2460,16 +2460,6 @@ static struct config_int ConfigureNamesInt[] =
 	},
 
 	{
-		{"lsn_cache_size", PGC_POSTMASTER, UNGROUPED,
-			gettext_noop("Size of last written LSN cache used by Neon."),
-			NULL
-		},
-		&lastWrittenLsnCacheSize,
-		128*1024, 1024, INT_MAX,
-		NULL, NULL, NULL
-	},
-
-	{
 		{"temp_buffers", PGC_USERSET, RESOURCES_MEM,
 			gettext_noop("Sets the maximum number of temporary buffers used by each session."),
 			NULL,

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -257,19 +257,19 @@ extern XLogRecPtr GetLastImportantRecPtr(void);
 /* neon specifics */
 
 /* Hooks for LwLSN */
+typedef XLogRecPtr (*set_lwlsn_block_hook_type)(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum, BlockNumber blkno);
 typedef XLogRecPtr (*set_lwlsn_block_range_hook_type)(XLogRecPtr lsn, RelFileNode rnode, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks);
 typedef XLogRecPtr (*set_lwlsn_block_v_hook_type)(const XLogRecPtr *lsns, RelFileNode relfilenode, ForkNumber forknum, BlockNumber blockno, int nblocks);
-typedef XLogRecPtr (*set_lwlsn_block_hook_type)(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum, BlockNumber blkno);
-typedef XLogRecPtr (*set_lwlsn_relation_hook_type)(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum);
 typedef XLogRecPtr (*set_lwlsn_db_hook_type)(XLogRecPtr lsn);
-typedef void (*update_max_lwlsn_hook_type) (XLogRecPtr lsn);
+typedef XLogRecPtr (*set_lwlsn_relation_hook_type)(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum);
+typedef void (*set_max_lwlsn_hook_type) (XLogRecPtr lsn);
 
+extern set_lwlsn_block_hook_type set_lwlsn_block_hook;
 extern set_lwlsn_block_range_hook_type set_lwlsn_block_range_hook;
 extern set_lwlsn_block_v_hook_type set_lwlsn_block_v_hook;
-extern set_lwlsn_block_hook_type set_lwlsn_block_hook;
-extern set_lwlsn_relation_hook_type set_lwlsn_relation_hook;
 extern set_lwlsn_db_hook_type set_lwlsn_db_hook;
-extern update_max_lwlsn_hook_type update_max_lwlsn_hook;
+extern set_lwlsn_relation_hook_type set_lwlsn_relation_hook;
+extern set_max_lwlsn_hook_type set_max_lwlsn_hook;
 
 extern void SetRedoStartLsn(XLogRecPtr RedoStartLSN);
 extern XLogRecPtr GetRedoStartLsn(void);

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -63,7 +63,6 @@ extern PGDLLIMPORT bool track_wal_io_timing;
 extern PGDLLIMPORT int wal_decode_buffer_size;
 
 extern PGDLLIMPORT int CheckPointSegments;
-extern int  lastWrittenLsnCacheSize;
 
 
 /* Archive modes */
@@ -261,7 +260,25 @@ extern XLogRecPtr SetLastWrittenLSNForBlock(XLogRecPtr lsn, RelFileNode relfilen
 extern XLogRecPtr SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks);
 extern XLogRecPtr SetLastWrittenLSNForDatabase(XLogRecPtr lsn);
 extern XLogRecPtr SetLastWrittenLSNForRelation(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum);
-extern XLogRecPtr GetLastWrittenLSN(RelFileNode relfilenode, ForkNumber forknum, BlockNumber blkno);
+
+/* Hooks for LwLSN */
+typedef XLogRecPtr (*get_lwlsn_hook_type)(RelFileNode relfilenode, ForkNumber forknum, BlockNumber blkno);
+typedef void (*get_lwlsn_v_hook_type)(RelFileNode relfilenode, ForkNumber forknum, BlockNumber blkno, int nblocks, XLogRecPtr *lsns);
+typedef XLogRecPtr (*set_lwlsn_block_range_hook_type)(XLogRecPtr lsn, RelFileNode rnode, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks);
+typedef XLogRecPtr (*set_lwlsn_block_v_hook_type)(const XLogRecPtr *lsns, RelFileNode relfilenode, ForkNumber forknum, BlockNumber blockno, int nblocks);
+typedef XLogRecPtr (*set_lwlsn_block_hook_type)(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum, BlockNumber blkno);
+typedef XLogRecPtr (*set_lwlsn_relation_hook_type)(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum);
+typedef XLogRecPtr (*set_lwlsn_db_hook_type)(XLogRecPtr lsn);
+typedef int (*get_lwlsn_cache_size_type) (void);
+
+extern get_lwlsn_hook_type get_lwlsn_hook;
+extern get_lwlsn_v_hook_type get_lwlsn_v_hook;
+extern set_lwlsn_block_range_hook_type set_lwlsn_block_range_hook;
+extern set_lwlsn_block_v_hook_type set_lwlsn_block_v_hook;
+extern set_lwlsn_block_hook_type set_lwlsn_block_hook;
+extern set_lwlsn_relation_hook_type set_lwlsn_relation_hook;
+extern set_lwlsn_db_hook_type set_lwlsn_db_hook;
+extern get_lwlsn_cache_size_type get_lwlsn_cache_size;
 
 extern void SetRedoStartLsn(XLogRecPtr RedoStartLSN);
 extern XLogRecPtr GetRedoStartLsn(void);

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -256,20 +256,19 @@ extern XLogRecPtr GetLastImportantRecPtr(void);
 
 /* neon specifics */
 
-extern XLogRecPtr SetLastWrittenLSNForBlock(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum, BlockNumber blkno);
-extern XLogRecPtr SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks);
-extern XLogRecPtr SetLastWrittenLSNForDatabase(XLogRecPtr lsn);
-extern XLogRecPtr SetLastWrittenLSNForRelation(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum);
-
 /* Hooks for LwLSN */
 typedef XLogRecPtr (*set_lwlsn_block_range_hook_type)(XLogRecPtr lsn, RelFileNode rnode, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks);
 typedef XLogRecPtr (*set_lwlsn_block_v_hook_type)(const XLogRecPtr *lsns, RelFileNode relfilenode, ForkNumber forknum, BlockNumber blockno, int nblocks);
 typedef XLogRecPtr (*set_lwlsn_block_hook_type)(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum, BlockNumber blkno);
+typedef XLogRecPtr (*set_lwlsn_relation_hook_type)(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum);
+typedef XLogRecPtr (*set_lwlsn_db_hook_type)(XLogRecPtr lsn);
 typedef void (*update_max_lwlsn_hook_type) (XLogRecPtr lsn);
 
 extern set_lwlsn_block_range_hook_type set_lwlsn_block_range_hook;
 extern set_lwlsn_block_v_hook_type set_lwlsn_block_v_hook;
 extern set_lwlsn_block_hook_type set_lwlsn_block_hook;
+extern set_lwlsn_relation_hook_type set_lwlsn_relation_hook;
+extern set_lwlsn_db_hook_type set_lwlsn_db_hook;
 extern update_max_lwlsn_hook_type update_max_lwlsn_hook;
 
 extern void SetRedoStartLsn(XLogRecPtr RedoStartLSN);

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -235,7 +235,7 @@ extern uint64 GetSystemIdentifier(void);
 extern char *GetMockAuthenticationNonce(void);
 extern bool DataChecksumsEnabled(void);
 extern XLogRecPtr GetFakeLSNForUnloggedRel(void);
-extern Size XLOGShmemSize(void);
+extern Size XLOGCtlShmemSize(void);
 extern void XLOGShmemInit(void);
 extern void BootStrapXLOG(void);
 extern void LocalProcessControlFile(bool reset);

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -235,7 +235,7 @@ extern uint64 GetSystemIdentifier(void);
 extern char *GetMockAuthenticationNonce(void);
 extern bool DataChecksumsEnabled(void);
 extern XLogRecPtr GetFakeLSNForUnloggedRel(void);
-extern Size XLOGCtlShmemSize(void);
+extern Size XLOGShmemSize(void);
 extern void XLOGShmemInit(void);
 extern void BootStrapXLOG(void);
 extern void LocalProcessControlFile(bool reset);

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -262,24 +262,14 @@ extern XLogRecPtr SetLastWrittenLSNForDatabase(XLogRecPtr lsn);
 extern XLogRecPtr SetLastWrittenLSNForRelation(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum);
 
 /* Hooks for LwLSN */
-typedef XLogRecPtr (*get_lwlsn_hook_type)(RelFileNode relfilenode, ForkNumber forknum, BlockNumber blkno);
-typedef void (*get_lwlsn_v_hook_type)(RelFileNode relfilenode, ForkNumber forknum, BlockNumber blkno, int nblocks, XLogRecPtr *lsns);
 typedef XLogRecPtr (*set_lwlsn_block_range_hook_type)(XLogRecPtr lsn, RelFileNode rnode, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks);
 typedef XLogRecPtr (*set_lwlsn_block_v_hook_type)(const XLogRecPtr *lsns, RelFileNode relfilenode, ForkNumber forknum, BlockNumber blockno, int nblocks);
 typedef XLogRecPtr (*set_lwlsn_block_hook_type)(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum, BlockNumber blkno);
-typedef XLogRecPtr (*set_lwlsn_relation_hook_type)(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum);
-typedef XLogRecPtr (*set_lwlsn_db_hook_type)(XLogRecPtr lsn);
-typedef int (*get_lwlsn_cache_size_type) (void);
 typedef void (*update_max_lwlsn_hook_type) (XLogRecPtr lsn);
 
-extern get_lwlsn_hook_type get_lwlsn_hook;
-extern get_lwlsn_v_hook_type get_lwlsn_v_hook;
 extern set_lwlsn_block_range_hook_type set_lwlsn_block_range_hook;
 extern set_lwlsn_block_v_hook_type set_lwlsn_block_v_hook;
 extern set_lwlsn_block_hook_type set_lwlsn_block_hook;
-extern set_lwlsn_relation_hook_type set_lwlsn_relation_hook;
-extern set_lwlsn_db_hook_type set_lwlsn_db_hook;
-extern get_lwlsn_cache_size_type get_lwlsn_cache_size;
 extern update_max_lwlsn_hook_type update_max_lwlsn_hook;
 
 extern void SetRedoStartLsn(XLogRecPtr RedoStartLSN);

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -270,6 +270,7 @@ typedef XLogRecPtr (*set_lwlsn_block_hook_type)(XLogRecPtr lsn, RelFileNode relf
 typedef XLogRecPtr (*set_lwlsn_relation_hook_type)(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum);
 typedef XLogRecPtr (*set_lwlsn_db_hook_type)(XLogRecPtr lsn);
 typedef int (*get_lwlsn_cache_size_type) (void);
+typedef void (*update_max_lwlsn_hook_type) (XLogRecPtr lsn);
 
 extern get_lwlsn_hook_type get_lwlsn_hook;
 extern get_lwlsn_v_hook_type get_lwlsn_v_hook;
@@ -279,6 +280,7 @@ extern set_lwlsn_block_hook_type set_lwlsn_block_hook;
 extern set_lwlsn_relation_hook_type set_lwlsn_relation_hook;
 extern set_lwlsn_db_hook_type set_lwlsn_db_hook;
 extern get_lwlsn_cache_size_type get_lwlsn_cache_size;
+extern update_max_lwlsn_hook_type update_max_lwlsn_hook;
 
 extern void SetRedoStartLsn(XLogRecPtr RedoStartLSN);
 extern XLogRecPtr GetRedoStartLsn(void);


### PR DESCRIPTION
Removing the LastWrittenLSN code from Postgres v15 as part of moving it into the neon extension to reduce code duplication.

Part of: https://github.com/neondatabase/neon/issues/10973