### PR TITLE
Set last-written LSN as part of smgr_end_unlogged_build()

### DIFF
--- a/src/backend/access/gin/gininsert.c
+++ b/src/backend/access/gin/gininsert.c
@@ -421,10 +421,6 @@ ginbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 		log_newpage_range(index, MAIN_FORKNUM,
 						  0, RelationGetNumberOfBlocks(index),
 						  true);
-		if (set_lwlsn_block_range_hook)
-			set_lwlsn_block_range_hook(XactLastRecEnd, index->rd_smgr->smgr_rnode.node, MAIN_FORKNUM, 0, RelationGetNumberOfBlocks(index));
-		if (set_lwlsn_relation_hook)
-			set_lwlsn_relation_hook(XactLastRecEnd, index->rd_smgr->smgr_rnode.node, MAIN_FORKNUM);
 	}
 
 	smgr_end_unlogged_build(index->rd_smgr);

--- a/src/backend/access/gist/gistbuild.c
+++ b/src/backend/access/gist/gistbuild.c
@@ -342,12 +342,6 @@ gistbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 			log_newpage_range(index, MAIN_FORKNUM,
 							  0, RelationGetNumberOfBlocks(index),
 							  true);
-			if (set_lwlsn_block_range_hook)
-				set_lwlsn_block_range_hook(XactLastRecEnd,
-								index->rd_smgr->smgr_rnode.node,
-								MAIN_FORKNUM, 0, RelationGetNumberOfBlocks(index));
-			if (set_lwlsn_relation_hook)
-				set_lwlsn_relation_hook(XactLastRecEnd, index->rd_smgr->smgr_rnode.node, MAIN_FORKNUM);
 		}
 		smgr_end_unlogged_build(index->rd_smgr);
 	}

--- a/src/backend/access/spgist/spginsert.c
+++ b/src/backend/access/spgist/spginsert.c
@@ -144,11 +144,6 @@ spgbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 		log_newpage_range(index, MAIN_FORKNUM,
 						  0, RelationGetNumberOfBlocks(index),
 						  true);
-		if (set_lwlsn_block_range_hook)
-			set_lwlsn_block_range_hook(XactLastRecEnd, index->rd_smgr->smgr_rnode.node,
-							MAIN_FORKNUM, 0, RelationGetNumberOfBlocks(index));
-		if (set_lwlsn_relation_hook)
-			set_lwlsn_relation_hook(XactLastRecEnd, index->rd_smgr->smgr_rnode.node, MAIN_FORKNUM);
 	}
 
 	smgr_end_unlogged_build(index->rd_smgr);


### PR DESCRIPTION
This way, the callers don't need to do it, reducing the footprint of changes we've had to made to various index AM's build functions.

Note that the changes to smgr_end_unlogged_build() are in the neon repository. Here in the postgres code, we can just remove the set_lwlsn hook calls now. (There's no harm in calling them twice, so if there's an extension out there still making those calls, that's OK.)

main PR: https://github.com/neondatabase/neon/pull/11584