### PR TITLE
XLog: Expose WAL replay progress test [PG15]

### DIFF
--- a/src/backend/access/transam/xlogrecovery.c
+++ b/src/backend/access/transam/xlogrecovery.c
@@ -489,6 +489,27 @@ EnableStandbyMode(void)
 	disable_startup_progress_timeout();
 }
 
+static XLogRecPtr replayRecPtr = InvalidXLogRecPtr;
+
+bool
+XLogRecordReplayFinished(XLogRecPtr redoEndRecPtr)
+{
+	if (!RecoveryInProgress())
+		return true;
+
+	/*
+	 * Check the backend-local variable first, we may be able to skip accessing
+	 * shared memory (which requires locking)
+	 */
+	if (redoEndRecPtr <= replayRecPtr)
+		return true;
+
+	/* update the backend-local cache with more up-to-date values */
+	replayRecPtr = GetXLogReplayRecPtr(NULL);
+
+	return redoEndRecPtr <= replayRecPtr;
+}
+
 /*
  * Wait for recovery to complete replaying all WAL up to and including
  * redoEndRecPtr.
@@ -499,25 +520,14 @@ EnableStandbyMode(void)
 void
 XLogWaitForReplayOf(XLogRecPtr redoEndRecPtr)
 {
-	static XLogRecPtr replayRecPtr = 0;
-
-	if (!RecoveryInProgress())
-		return;
-
 	/*
-	 * Check the backend-local variable first, we may be able to skip accessing
-	 * shared memory (which requires locking)
+	 * Check if the record has been replayed yet. This includes up-to-date
+	 * information about current replay state - if it hasn't been replayed,
+	 * we're probably going to have to wait.
+	 *
+	 * This also returns if we're not in recovery mode.
 	 */
-	if (redoEndRecPtr <= replayRecPtr)
-		return;
-
-	replayRecPtr = GetXLogReplayRecPtr(NULL);
-
-	/*
-	 * Check again if we're going to need to wait, now that we've updated
-	 * the local cached variable.
-	 */
-	if (redoEndRecPtr <= replayRecPtr)
+	if (XLogRecordReplayFinished(redoEndRecPtr))
 		return;
 
 	/*

--- a/src/include/access/xlogrecovery.h
+++ b/src/include/access/xlogrecovery.h
@@ -136,6 +136,7 @@ extern void ShutdownWalRecovery(void);
 extern void RemovePromoteSignalFiles(void);
 
 extern bool HotStandbyActive(void);
+extern bool XLogRecordReplayFinished(XLogRecPtr redoEndRecPtr);
 extern void XLogWaitForReplayOf(XLogRecPtr redoEndRecPtr);
 extern XLogRecPtr GetXLogReplayRecPtr(TimeLineID *replayTLI);
 extern RecoveryPauseState GetRecoveryPauseState(void);


### PR DESCRIPTION
This allows extension code to check how far REDO has come, and potentially wait or change control flow based on REDO progress.