### PR TITLE
pg_dump: Add --schema-no-create option [PG14]

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -113,6 +113,8 @@ static SimpleOidList schema_include_oids = {NULL, NULL};
 static SimpleStringList schema_exclude_patterns = {NULL, NULL};
 static SimpleOidList schema_exclude_oids = {NULL, NULL};
 
+static SimpleStringList schema_include_no_create_patterns = {NULL, NULL};
+
 static SimpleStringList table_include_patterns = {NULL, NULL};
 static SimpleOidList table_include_oids = {NULL, NULL};
 static SimpleStringList table_exclude_patterns = {NULL, NULL};
@@ -402,6 +404,7 @@ main(int argc, char **argv)
 		{"on-conflict-do-nothing", no_argument, &dopt.do_nothing, 1},
 		{"rows-per-insert", required_argument, NULL, 10},
 		{"include-foreign-data", required_argument, NULL, 11},
+		{"schema-no-create", required_argument, NULL, 12},
 
 		{NULL, 0, NULL, 0}
 	};
@@ -622,6 +625,16 @@ main(int argc, char **argv)
 			case 11:			/* include foreign data */
 				simple_string_list_append(&foreign_servers_include_patterns,
 										  optarg);
+				break;
+
+			case 12:			/* schema-no-create */
+				simple_string_list_append(&schema_include_no_create_patterns,
+											optarg);
+				/*
+				 * Also include the schema in the regular include list,
+				 * because we need to dump the data.
+				 */
+				simple_string_list_append(&schema_include_patterns, optarg);
 				break;
 
 			default:
@@ -1080,6 +1093,7 @@ help(const char *progname)
 	printf(_("  --on-conflict-do-nothing     add ON CONFLICT DO NOTHING to INSERT commands\n"));
 	printf(_("  --quote-all-identifiers      quote all identifiers, even if not key words\n"));
 	printf(_("  --rows-per-insert=NROWS      number of rows per INSERT; implies --inserts\n"));
+	printf(_("  --schema-no-create=SCHEMA    do not create the specified schema(s)\n"));
 	printf(_("  --section=SECTION            dump named section (pre-data, data, or post-data)\n"));
 	printf(_("  --serializable-deferrable    wait until the dump can run without anomalies\n"));
 	printf(_("  --snapshot=SNAPSHOT          use given snapshot for the dump\n"));
@@ -1669,12 +1683,17 @@ checkExtensionMembership(DumpableObject *dobj, Archive *fout)
 static void
 selectDumpableNamespace(NamespaceInfo *nsinfo, Archive *fout)
 {
+	if (simple_string_list_member(&schema_include_no_create_patterns, nsinfo->dobj.name))
+	{
+		nsinfo->dobj.dump = DUMP_COMPONENT_ACL;
+		nsinfo->dobj.dump_contains = DUMP_COMPONENT_ALL;
+	}
 	/*
 	 * If specific tables are being dumped, do not dump any complete
 	 * namespaces. If specific namespaces are being dumped, dump just those
 	 * namespaces. Otherwise, dump all non-system namespaces.
 	 */
-	if (table_include_oids.head != NULL)
+	else if (table_include_oids.head != NULL)
 		nsinfo->dobj.dump_contains = nsinfo->dobj.dump = DUMP_COMPONENT_NONE;
 	else if (schema_include_oids.head != NULL)
 		nsinfo->dobj.dump_contains = nsinfo->dobj.dump =


### PR DESCRIPTION
Adds a new `--schema-no-create` option to `pg_dump` that allows dumping schema data without generating `CREATE SCHEMA` statements. When this option is used, the specified schema is automatically included in the dump but the schema creation statement is skipped, allowing data to be imported into existing schemas.

This option is used by the Neon fast import feature ([PR #11908](https://github.com/neondatabase/neon/pull/11908)) to allow migrations of only objects in certain schemas.

Usage: `pg_dump --schema-no-create=schema_name database_name`