### PR TITLE
backport: Use normal install program to install server headers.

### DIFF
--- a/src/include/Makefile
+++ b/src/include/Makefile
@@ -47,22 +47,15 @@ install: all installdirs
 	$(INSTALL_DATA) utils/errcodes.h '$(DESTDIR)$(includedir_server)/utils'
 	$(INSTALL_DATA) utils/fmgroids.h '$(DESTDIR)$(includedir_server)/utils'
 	$(INSTALL_DATA) utils/fmgrprotos.h '$(DESTDIR)$(includedir_server)/utils'
-# We don't use INSTALL_DATA for performance reasons --- there are a lot of files
-# (in fact, we have to take some pains to avoid overlength shell commands here)
-	cp $(srcdir)/*.h '$(DESTDIR)$(includedir_server)'/
+	$(INSTALL_DATA) $(srcdir)/*.h '$(DESTDIR)$(includedir_server)'
 	for dir in $(SUBDIRS); do \
-	  cp $(srcdir)/$$dir/*.h '$(DESTDIR)$(includedir_server)'/$$dir/ || exit; \
+	  $(INSTALL_DATA) $(srcdir)/$$dir/*.h '$(DESTDIR)$(includedir_server)'/$$dir || exit; \
 	done
 ifeq ($(vpath_build),yes)
 	for file in catalog/schemapg.h catalog/system_fk_info.h catalog/pg_*_d.h parser/gram.h storage/lwlocknames.h utils/probes.h; do \
-	  cp $$file '$(DESTDIR)$(includedir_server)'/$$file || exit; \
+	  $(INSTALL_DATA) $$file '$(DESTDIR)$(includedir_server)'/$$file || exit; \
 	done
 endif
-	cd '$(DESTDIR)$(includedir_server)' && chmod $(INSTALL_DATA_MODE) *.h
-	for dir in $(SUBDIRS); do \
-	  cd '$(DESTDIR)$(includedir_server)'/$$dir || exit; \
-	  chmod $(INSTALL_DATA_MODE) *.h || exit; \
-	done
 
 installdirs:
 	$(MKDIR_P) '$(DESTDIR)$(includedir)/libpq' '$(DESTDIR)$(includedir_internal)/libpq'


### PR DESCRIPTION
This is a backport of PostgreSQL commit c0a1d7621b to REL_14_STABLE. Our top-level Makefile in the neon repository depends on "make install" not modifying the mtimes on the headers, if there have been no changes to them. Otherwise, the `postgres_ffi` rust crate and all the other components that depends on it get rebuilt every time you run `make`.