### PR TITLE
Only allocate and use the buffer for SLRU segment with the old communicator.

### DIFF
--- a/src/backend/access/transam/slru.c
+++ b/src/backend/access/transam/slru.c
@@ -762,7 +762,12 @@ SimpleLruDownloadSegment(SlruCtl ctl, int pageno, char const* path)
 	}
 	segno = pageno / SLRU_PAGES_PER_SEGMENT;
 
-	buffer = palloc(BLCKSZ * SLRU_PAGES_PER_SEGMENT);
+	if (neon_use_communicator_worker) {
+		buffer = NULL;
+	} else {
+		buffer = palloc(BLCKSZ * SLRU_PAGES_PER_SEGMENT);
+	}
+
 	n_blocks = smgr_read_slru_segment(&dummy_smgr_rel, path, segno, buffer);
 	if (n_blocks > 0)
 	{
@@ -774,22 +779,25 @@ SimpleLruDownloadSegment(SlruCtl ctl, int pageno, char const* path)
 			pfree(buffer);
 			return -1;
 		}
-		errno = 0;
-		pgstat_report_wait_start(WAIT_EVENT_SLRU_WRITE);
-		if (pg_pwrite(fd, buffer, n_blocks*BLCKSZ, 0) != n_blocks*BLCKSZ)
-		{
-			pgstat_report_wait_end();
-			/* if write didn't set errno, assume problem is no disk space */
-			if (errno == 0)
-				errno = ENOSPC;
-			slru_errcause = SLRU_WRITE_FAILED;
-			slru_errno = errno;
 
-			CloseTransientFile(fd);
-			pfree(buffer);
-			return -1;
+		if (!neon_use_communicator_worker) {
+			errno = 0;
+			pgstat_report_wait_start(WAIT_EVENT_SLRU_WRITE);
+			if (pg_pwrite(fd, buffer, n_blocks*BLCKSZ, 0) != n_blocks*BLCKSZ)
+			{
+				pgstat_report_wait_end();
+				/* if write didn't set errno, assume problem is no disk space */
+				if (errno == 0)
+					errno = ENOSPC;
+				slru_errcause = SLRU_WRITE_FAILED;
+				slru_errno = errno;
+
+				CloseTransientFile(fd);
+				pfree(buffer);
+				return -1;
+			}
+			pgstat_report_wait_end();
 		}
-		pgstat_report_wait_end();
 	}
 	pfree(buffer);
 	return fd;

--- a/src/backend/utils/init/globals.c
+++ b/src/backend/utils/init/globals.c
@@ -116,6 +116,7 @@ pid_t		PostmasterPid = 0;
 bool		IsPostmasterEnvironment = false;
 bool		IsUnderPostmaster = false;
 bool		IsBinaryUpgrade = false;
+bool		neon_use_communicator_worker = false;
 
 bool		ExitOnAnyError = false;
 

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -170,6 +170,12 @@ extern PGDLLIMPORT pid_t PostmasterPid;
 extern PGDLLIMPORT bool IsPostmasterEnvironment;
 extern PGDLLIMPORT bool IsUnderPostmaster;
 extern PGDLLIMPORT bool IsBinaryUpgrade;
+/* Whether the communicator worker is used or not. Defined here so that
+ * it is also accessible from the main postgres code easily without
+ * having to look up the value using strings and chain of other
+ * functions.
+ */
+extern PGDLLIMPORT bool neon_use_communicator_worker;
 
 extern PGDLLIMPORT bool ExitOnAnyError;
 


### PR DESCRIPTION
This is a part of the communicator rewrite. The new communicator directly writes to the file instead of using a temporary buffer.