### PR TITLE
Allow seeing query texts for inherited roles in pg_stat_statements (#20)

### DIFF
--- a/contrib/pg_stat_statements/pg_stat_statements.c
+++ b/contrib/pg_stat_statements/pg_stat_statements.c
@@ -1692,7 +1692,7 @@ pg_stat_statements_internal(FunctionCallInfo fcinfo,
 		if (api_version >= PGSS_V1_9)
 			values[i++] = BoolGetDatum(entry->key.toplevel);
 
-		if (is_allowed_role || entry->key.userid == userid)
+		if (is_allowed_role || has_privs_of_role(userid, entry->key.userid))
 		{
 			if (api_version >= PGSS_V1_2)
 				values[i++] = Int64GetDatumFast(queryid);


### PR DESCRIPTION
Today, if you don't have pg_monitor (pg_read_all_stats, specifically), you can only see your own query texts in pg_stat_statements. This limits the usefulness quite a bit because we're not ready to give out pg_monitor yet.

pg_stat_activity however is more lax and lets you see the query text of roles you inherit the privileges of. See
[here](https://github.com/databricks-eng/postgres/blob/REL_16_STABLE_hadron/src/backend/utils/adt/pgstatfuncs.c#L39).

This PR aligns the behavior of pg_stat_statements with pg_stat_activity. Later in PrPr when we give out pg_monitor, we can choose whether we keep this or not.

I manually verified the new behavior. Will follow up with an automated test as a fast-follow to PrPr for the final behavior when we give out pg_monitor. Manual test:

```sql
SET ROLE cloud_admin
-- Create a role u1 simulating endpoint creator.
CREATE ROLE u1 WITH CREATEROLE;
GRANT databricks_superuser TO u1;
GRANT ALL PRIVILEGES ON SCHEMA public TO u1 WITH GRANT OPTION;

-- Now, as endpoint creator, create a second user.
SET ROLE u1;
CREATE ROLE u2;
GRANT ALL PRIVILEGES ON SCHEMA public to u2;

-- As the second user, create a dingding table.
SET ROLE u2;
CREATE TABLE tbl_dingding(a INT);
INSERT INTO tbl_dingding VALUES (1);

-- Now, as endpoint creator again, try to see what u2 did.
-- This is NOT visible because u1 doesn't have u2's privileges.
SET ROLE u1;
CREATE EXTENSION pg_stat_statements
SELECT * FROM pg_stat_statements WHERE query LIKE '%tbl_dingding%'	

-- But since u1 created u2, u1 has ADMIN on u2 and can grant itself its privileges.
-- Now u1 can see u2's dingding query. This is only possible because of the change in this PR.
GRANT u2 to u1;
SELECT * FROM pg_stat_statements WHERE query LIKE '%tbl_dingding%'
```

---------