### PR TITLE
[Hadron] Skip logging statements that may have a cleartext password

### DIFF
--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -264,6 +264,25 @@ should_output_to_client(int elevel)
 	return false;
 }
 
+/*
+ * Hadron -- check if the statement may have a password by checking if the
+ * statement contains the word "password" in it.
+ */
+static inline bool
+statement_may_have_password(void) {
+	if (debug_query_string == NULL)
+		return false;
+	for (const char *query_substring = debug_query_string;
+		 *query_substring != '\0';
+		 query_substring++)
+	{
+		// n=8 so that we are doing a substring check
+		if (pg_strncasecmp(query_substring, "password", 8) == 0)
+			return true;
+	}
+	return false;
+}
+
 
 /*
  * message_level_is_interesting --- would ereport/elog do anything?
@@ -2732,6 +2751,10 @@ check_log_of_query(ErrorData *edata)
 
 	/* query string available? */
 	if (debug_query_string == NULL)
+		return false;
+	
+	/* Hadron */
+	if (statement_may_have_password())
 		return false;
 
 	return true;


### PR DESCRIPTION
Currently, `elog` with statement logging enabled (always or on severity) will log statements like `CREATE ROLE myrole WITH PASSWORD 'mypass';`, which means the password is written in cleartext to disk.

We want to enable statement logging for ERROR+ without having this issue.

This PR adds a check to the function that decides if the statement should be logged (used by both line and json logs). The approach is to check for the substring `PASSWORD` in the query string (case-insensitive).

Considerations:
- This may redact statements that do not have a password in them if the statement uses that as a substring of some object name, comment, etc.
- This may not redact statements that supply a password without using the keyword `PASSWORD`, e.g. if the user creates and calls a custom function for user creation (maybe they wrap `pg_databricks_create_role` so that it adds both the databricks identity and an optional password login option).
- Re-lowercases the same statement letters up to 8 times (and re-checks `"password"` [length of statement] times) but we should rarely reach this function because statements rarely cause errors, which is the log we are preventing.