### PR TITLE
Initialize the neon storage manager later at backend startup

### DIFF
--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -470,6 +470,16 @@ InitProcess(void)
 	 */
 	InitLWLockAccess();
 	InitDeadLockChecking();
+
+	/*
+	 * NEON: Initialize the neon storage manager. In vanilla Postgres, this is
+	 * called from BaseInit(), which runs earlier. But we want to have MyProc
+	 * available, so we run it here instead.
+	 *
+	 * In later Postgres versions, smgrinit() is called later, and this change
+	 * is no longer required.
+	 */
+	smgrinit();
 }
 
 /*
@@ -624,6 +634,9 @@ InitAuxiliaryProcess(void)
 	 * Arrange to clean up at process exit.
 	 */
 	on_shmem_exit(AuxiliaryProcKill, Int32GetDatum(proctype));
+
+	/* NEON: see InitProcess */
+	smgrinit();
 }
 
 /*

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -549,7 +549,8 @@ BaseInit(void)
 	/* Do local initialization of file, storage and buffer managers */
 	InitFileAccess();
 	InitSync();
-	smgrinit();
+	/* NEON: This is done later, in InitProcess() */
+	/* smgrinit(); */
 	InitBufferPoolAccess();
 }
 


### PR DESCRIPTION
This way MyProc is available in the initialization function. This is for v14 only; on later Postgres versions smgrinit() is called after InitProcess().