### PR TITLE
Add hook in pg_signal_backend()

### DIFF
--- a/src/backend/storage/ipc/signalfuncs.c
+++ b/src/backend/storage/ipc/signalfuncs.c
@@ -20,12 +20,15 @@
 #include "miscadmin.h"
 #include "pgstat.h"
 #include "postmaster/syslogger.h"
+#include "storage/ipc.h"
 #include "storage/pmsignal.h"
 #include "storage/proc.h"
 #include "storage/procarray.h"
 #include "utils/acl.h"
 #include "utils/fmgrprotos.h"
 
+
+pg_signal_backend_hook_type pg_signal_backend_hook = NULL;
 
 /*
  * Send a signal to another backend.
@@ -49,6 +52,9 @@ static int
 pg_signal_backend(int pid, int sig)
 {
 	PGPROC	   *proc = BackendPidGetProc(pid);
+
+	if (pg_signal_backend_hook)
+		pg_signal_backend_hook();
 
 	/*
 	 * BackendPidGetProc returns NULL if the pid isn't valid; but by the time

--- a/src/include/storage/ipc.h
+++ b/src/include/storage/ipc.h
@@ -21,6 +21,10 @@
 typedef void (*pg_on_exit_callback) (int code, Datum arg);
 typedef void (*shmem_startup_hook_type) (void);
 
+/* NEON: The hook is called when a backend is about to be signaled. */
+typedef void (*pg_signal_backend_hook_type) ();
+extern PGDLLIMPORT pg_signal_backend_hook_type pg_signal_backend_hook;
+
 /*----------
  * API for handling cleanup that must occur during either ereport(ERROR)
  * or ereport(FATAL) exits from a block of code.  (Typical examples are


### PR DESCRIPTION
The purpose of the hook is to facilitate Lakebase's behavior of not allowing customers to cancel queries on replicas.

Lakebase exposes a single endpoint to customers unlike Neon, where there is an endpoint for the primary and all replicas. Lakebase has had customer issues where they do the following:

	# On connection 1
	SELECT pid from pg_stat_activity WHERE ...;

	# On connection 2
	SELECT pg_cancel_backend(pid) -- Where pid is from connection 1

Connection 2 is not guaranteed to go to the same endpoint, so a customer may call pg_cancel_backend() on the wrong endpoint. Commonly, this will end up in an error because the PID does not exist, but in rare cases PIDs will align across endpoints, and the customer will cancel a query they didn't want to cancel.

Whether we want to keep this hook indefinitely requires talking to product, and explaining the situation.