### PR TITLE
Add global temp file size limit

### DIFF
--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -167,6 +167,8 @@ int			recovery_init_sync_method = DATA_DIR_SYNC_METHOD_FSYNC;
 /* Which kinds of files should be opened with PG_O_DIRECT. */
 int			io_direct_flags;
 
+CheckTempFileSize_hook_type CheckTempFileSize_hook = NULL;
+
 /* Debugging.... */
 
 #ifdef FDDEBUG
@@ -2010,6 +2012,10 @@ FileClose(File file)
 	{
 		/* Subtract its size from current usage (do first in case of error) */
 		temporary_files_size -= vfdP->fileSize;
+		if (CheckTempFileSize_hook != NULL)
+		{
+			CheckTempFileSize_hook(vfdP->fileSize, PG_TEMP_FILES_SIZE_DEC);
+		}
 		vfdP->fileSize = 0;
 	}
 
@@ -2233,6 +2239,10 @@ FileWriteV(File file, const struct iovec *iov, int iovcnt, off_t offset,
 						(errcode(ERRCODE_CONFIGURATION_LIMIT_EXCEEDED),
 						 errmsg("temporary file size exceeds temp_file_limit (%dkB)",
 								temp_file_limit)));
+			if (CheckTempFileSize_hook != NULL)
+			{
+				CheckTempFileSize_hook(past_write - vfdP->fileSize, PG_TEMP_FILES_SIZE_CHECK);
+			}
 		}
 	}
 
@@ -2262,6 +2272,10 @@ retry:
 			if (past_write > vfdP->fileSize)
 			{
 				temporary_files_size += past_write - vfdP->fileSize;
+				if (CheckTempFileSize_hook != NULL)
+				{
+					CheckTempFileSize_hook(past_write - vfdP->fileSize, PG_TEMP_FILES_SIZE_INC);
+				}
 				vfdP->fileSize = past_write;
 			}
 		}
@@ -2445,6 +2459,10 @@ FileTruncate(File file, off_t offset, uint32 wait_event_info)
 		/* adjust our state for truncation of a temp file */
 		Assert(VfdCache[file].fdstate & FD_TEMP_FILE_LIMIT);
 		temporary_files_size -= VfdCache[file].fileSize - offset;
+		if (CheckTempFileSize_hook != NULL)
+		{
+			CheckTempFileSize_hook(VfdCache[file].fileSize - offset, PG_TEMP_FILES_SIZE_DEC);
+		}
 		VfdCache[file].fileSize = offset;
 	}
 
@@ -3184,6 +3202,11 @@ BeforeShmemExit_Files(int code, Datum arg)
 #ifdef USE_ASSERT_CHECKING
 	temporary_files_allowed = false;
 #endif
+
+	if (CheckTempFileSize_hook != NULL)
+	{
+		CheckTempFileSize_hook(temporary_files_size, PG_TEMP_FILES_SIZE_DEC);
+	}
 }
 
 /*

--- a/src/include/storage/fd.h
+++ b/src/include/storage/fd.h
@@ -216,4 +216,16 @@ FileWrite(File file, const void *buffer, size_t amount, off_t offset,
 	return FileWriteV(file, &iov, 1, offset, wait_event_info);
 }
 
+/* BEGIN_HADRON */
+#define PG_TEMP_FILES_SIZE_INC 0
+#define PG_TEMP_FILES_SIZE_DEC 1
+#define PG_TEMP_FILES_SIZE_CHECK 2
+typedef void (*CheckTempFileSize_hook_type) (off_t size, int action);
+extern PGDLLIMPORT CheckTempFileSize_hook_type CheckTempFileSize_hook;
+/* END_HADRON */
+
+/* Filename components */
+#define PG_TEMP_FILES_DIR "pgsql_tmp"
+#define PG_TEMP_FILE_PREFIX "pgsql_tmp"
+
 #endif							/* FD_H */


### PR DESCRIPTION
Ingestion is causing PG to run out of disk space due to temp files.

Maintain a global temp file size and error out the statement if size limit is reached.