### PR TITLE
Add global temp file size limit

### DIFF
--- a/src/backend/storage/file/fd.c
+++ b/src/backend/storage/file/fd.c
@@ -163,6 +163,11 @@ bool		data_sync_retry = false;
 /* How SyncDataDirectory() should do its job. */
 int			recovery_init_sync_method = RECOVERY_INIT_SYNC_METHOD_FSYNC;
 
+/* Which kinds of files should be opened with PG_O_DIRECT. */
+int			io_direct_flags;
+
+CheckTempFileSize_hook_type CheckTempFileSize_hook = NULL;
+
 /* Debugging.... */
 
 #ifdef FDDEBUG
@@ -1907,6 +1912,10 @@ FileClose(File file)
 	{
 		/* Subtract its size from current usage (do first in case of error) */
 		temporary_files_size -= vfdP->fileSize;
+		if (CheckTempFileSize_hook != NULL)
+		{
+			CheckTempFileSize_hook(vfdP->fileSize, PG_TEMP_FILES_SIZE_DEC);
+		}
 		vfdP->fileSize = 0;
 	}
 
@@ -2120,6 +2129,10 @@ FileWrite(File file, char *buffer, int amount, off_t offset,
 						(errcode(ERRCODE_CONFIGURATION_LIMIT_EXCEEDED),
 						 errmsg("temporary file size exceeds temp_file_limit (%dkB)",
 								temp_file_limit)));
+			if (CheckTempFileSize_hook != NULL)
+			{
+				CheckTempFileSize_hook(past_write - vfdP->fileSize, PG_TEMP_FILES_SIZE_CHECK);
+			}
 		}
 	}
 
@@ -2145,6 +2158,10 @@ retry:
 			if (past_write > vfdP->fileSize)
 			{
 				temporary_files_size += past_write - vfdP->fileSize;
+				if (CheckTempFileSize_hook != NULL)
+				{
+					CheckTempFileSize_hook(past_write - vfdP->fileSize, PG_TEMP_FILES_SIZE_INC);
+				}
 				vfdP->fileSize = past_write;
 			}
 		}
@@ -2237,6 +2254,10 @@ FileTruncate(File file, off_t offset, uint32 wait_event_info)
 		/* adjust our state for truncation of a temp file */
 		Assert(VfdCache[file].fdstate & FD_TEMP_FILE_LIMIT);
 		temporary_files_size -= VfdCache[file].fileSize - offset;
+		if (CheckTempFileSize_hook != NULL)
+		{
+			CheckTempFileSize_hook(VfdCache[file].fileSize - offset, PG_TEMP_FILES_SIZE_DEC);
+		}
 		VfdCache[file].fileSize = offset;
 	}
 
@@ -2971,6 +2992,11 @@ static void
 AtProcExit_Files(int code, Datum arg)
 {
 	CleanupTempFiles(false, true);
+
+	if (CheckTempFileSize_hook != NULL)
+	{
+		CheckTempFileSize_hook(temporary_files_size, PG_TEMP_FILES_SIZE_DEC);
+	}
 }
 
 /*

--- a/src/include/storage/fd.h
+++ b/src/include/storage/fd.h
@@ -174,6 +174,14 @@ extern int	durable_rename_excl(const char *oldfile, const char *newfile, int log
 extern void SyncDataDirectory(void);
 extern int	data_sync_elevel(int elevel);
 
+/* BEGIN_HADRON */
+#define PG_TEMP_FILES_SIZE_INC 0
+#define PG_TEMP_FILES_SIZE_DEC 1
+#define PG_TEMP_FILES_SIZE_CHECK 2
+typedef void (*CheckTempFileSize_hook_type) (off_t size, int action);
+extern PGDLLIMPORT CheckTempFileSize_hook_type CheckTempFileSize_hook;
+/* END_HADRON */
+
 /* Filename components */
 #define PG_TEMP_FILES_DIR "pgsql_tmp"
 #define PG_TEMP_FILE_PREFIX "pgsql_tmp"


### PR DESCRIPTION
Ingestion is causing PG to run out of disk space due to temp files.

Maintain a global temp file size and error out the statement if size limit is reached.