### PR TITLE
Remove unnecessary set_lwlsn_block_* hooks

### DIFF
--- a/src/backend/access/gist/gistbuild.c
+++ b/src/backend/access/gist/gistbuild.c
@@ -456,17 +456,6 @@ gist_indexsortbuild(GISTBuildState *state)
 	memcpy(rootbuf, levelstate->pages[0], BLCKSZ);
 	smgr_bulk_write(state->bulkstate, GIST_ROOT_BLKNO, rootbuf, true);
 
-	if (RelationNeedsWAL(state->indexrel))
-	{
-		XLogRecPtr lsn = GetRedoRecPtr();
-
-		if (set_lwlsn_block_hook)
-			set_lwlsn_block_hook(lsn, state->indexrel->rd_smgr->smgr_rlocator.locator,
-									MAIN_FORKNUM, GIST_ROOT_BLKNO);
-		if (set_lwlsn_relation_hook)
-			set_lwlsn_relation_hook(lsn, state->indexrel->rd_smgr->smgr_rlocator.locator, MAIN_FORKNUM);
-	}
-
 	pfree(levelstate);
 
 	smgr_bulk_finish(state->bulkstate);

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -149,9 +149,6 @@ int			wal_segment_size = DEFAULT_XLOG_SEG_SIZE;
 restore_running_xacts_callback_t restore_running_xacts_callback;
 
 /* NEON: Hooks to facilitate the last written LSN cache */
-set_lwlsn_block_hook_type set_lwlsn_block_hook = NULL;
-set_lwlsn_block_range_hook_type set_lwlsn_block_range_hook = NULL;
-set_lwlsn_block_v_hook_type set_lwlsn_block_v_hook = NULL;
 set_lwlsn_db_hook_type set_lwlsn_db_hook = NULL;
 set_lwlsn_relation_hook_type set_lwlsn_relation_hook = NULL;
 set_max_lwlsn_hook_type set_max_lwlsn_hook = NULL;

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -280,16 +280,10 @@ extern Size WALReadFromBuffers(char *dstbuf, XLogRecPtr startptr, Size count,
 							   TimeLineID tli);
 
 /* Hooks for LwLSN */
-typedef XLogRecPtr (*set_lwlsn_block_hook_type)(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum, BlockNumber blkno);
-typedef XLogRecPtr (*set_lwlsn_block_range_hook_type)(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks);
-typedef XLogRecPtr (*set_lwlsn_block_v_hook_type)(const XLogRecPtr *lsns, RelFileLocator relfilenode, ForkNumber forknum, BlockNumber blockno, int nblocks);
 typedef XLogRecPtr (*set_lwlsn_db_hook_type)(XLogRecPtr lsn);
 typedef XLogRecPtr (*set_lwlsn_relation_hook_type)(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum);
 typedef void (*set_max_lwlsn_hook_type) (XLogRecPtr lsn);
 
-extern set_lwlsn_block_hook_type set_lwlsn_block_hook;
-extern set_lwlsn_block_range_hook_type set_lwlsn_block_range_hook;
-extern set_lwlsn_block_v_hook_type set_lwlsn_block_v_hook;
 extern set_lwlsn_db_hook_type set_lwlsn_db_hook;
 extern set_lwlsn_relation_hook_type set_lwlsn_relation_hook;
 extern set_max_lwlsn_hook_type set_max_lwlsn_hook;


### PR DESCRIPTION
The hook calls from gist_indexsortbuild() on PostgreSQL 17 was unnecessary, because the smgr_bulk_*() functions perform smgrextend/smgrwrite calls and WAL-logging so that the last-written LSN cache is updated normally. (If they didn't, we'd have problems with B-tree index builds and anything else that uses the bulk-writing facility too.)

Remove those hook calls from gist_indexsortbuild(). That was the only usage of set_lwlsn_block_hook. set_lwlsn_block_range_hook and set_lwlsn_block_v_hook were unused even before this.