### PR TITLE
Remove unnecessary set_lwlsn_block_* hooks

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -150,9 +150,6 @@ int			wal_segment_size = DEFAULT_XLOG_SEG_SIZE;
 restore_running_xacts_callback_t restore_running_xacts_callback;
 
 /* NEON: Hook Definitions that enabled the moving of LastWrittenLSN Cache to the neon extension*/
-set_lwlsn_block_hook_type set_lwlsn_block_hook = NULL;
-set_lwlsn_block_range_hook_type set_lwlsn_block_range_hook = NULL;
-set_lwlsn_block_v_hook_type set_lwlsn_block_v_hook = NULL;
 set_lwlsn_db_hook_type set_lwlsn_db_hook = NULL;
 set_lwlsn_relation_hook_type set_lwlsn_relation_hook = NULL;
 set_max_lwlsn_hook_type set_max_lwlsn_hook = NULL;

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -262,16 +262,10 @@ extern XLogRecPtr GetLastImportantRecPtr(void);
 /* neon specifics */
 
 /* Hooks for LwLSN */
-typedef XLogRecPtr (*set_lwlsn_block_hook_type)(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum, BlockNumber blkno);
-typedef XLogRecPtr (*set_lwlsn_block_range_hook_type)(XLogRecPtr lsn, RelFileNode rnode, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks);
-typedef XLogRecPtr (*set_lwlsn_block_v_hook_type)(const XLogRecPtr *lsns, RelFileNode relfilenode, ForkNumber forknum, BlockNumber blockno, int nblocks);
 typedef XLogRecPtr (*set_lwlsn_db_hook_type)(XLogRecPtr lsn);
 typedef XLogRecPtr (*set_lwlsn_relation_hook_type)(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum);
 typedef void (*set_max_lwlsn_hook_type) (XLogRecPtr lsn);
 
-extern set_lwlsn_block_hook_type set_lwlsn_block_hook;
-extern set_lwlsn_block_range_hook_type set_lwlsn_block_range_hook;
-extern set_lwlsn_block_v_hook_type set_lwlsn_block_v_hook;
 extern set_lwlsn_db_hook_type set_lwlsn_db_hook;
 extern set_lwlsn_relation_hook_type set_lwlsn_relation_hook;
 extern set_max_lwlsn_hook_type set_max_lwlsn_hook;


### PR DESCRIPTION
The hook calls from gist_indexsortbuild() on PostgreSQL 17 was unnecessary, because the smgr_bulk_*() functions perform smgrextend/smgrwrite calls and WAL-logging so that the last-written LSN cache is updated normally. (If they didn't, we'd have problems with B-tree index builds and anything else that uses the bulk-writing facility too.)

Remove those hook calls from gist_indexsortbuild(). That was the only usage of set_lwlsn_block_hook. set_lwlsn_block_range_hook and set_lwlsn_block_v_hook were unused even before this.