### PR TITLE
Set xl_prev correctly if replica is promoted without replaying any records

### DIFF
--- a/src/backend/access/transam/xlogrecovery.c
+++ b/src/backend/access/transam/xlogrecovery.c
@@ -1804,7 +1804,22 @@ PerformWalRecovery(void)
 	 * checkpoint record itself, if it's a shutdown checkpoint).
 	 */
 	SpinLockAcquire(&XLogRecoveryCtl->info_lck);
-	if (RedoStartLSN < CheckPointLoc)
+	if (NeonRecoveryRequested)
+	{
+		/*
+		 * In Neon recovery mode, we can start from any record, not only at a
+		 * checkpoint. The Neon signal file includes an explicit "PREV LSN"
+		 * field, which is the LSN of the previous record, before the point at
+		 * which we start up. Initialize lastReplayedRecPtr from that, as if
+		 * we had just replayed that record.
+		 */
+		Assert(xlogreader->ReadRecPtr == InvalidXLogRecPtr);
+		Assert(xlogreader->EndRecPtr == RedoStartLSN);
+		XLogRecoveryCtl->lastReplayedEndRecPtr = RedoStartLSN;
+		XLogRecoveryCtl->lastReplayedReadRecPtr = neonLastRec;
+		XLogRecoveryCtl->lastReplayedTLI = CheckPointTLI;
+	}
+	else if (RedoStartLSN < CheckPointLoc)
 	{
 		XLogRecoveryCtl->lastReplayedReadRecPtr = InvalidXLogRecPtr;
 		XLogRecoveryCtl->lastReplayedEndRecPtr = RedoStartLSN;


### PR DESCRIPTION
Every WAL record in Postgres has a pointer to the start of the previous record (xl_prev). Postgres keeps track of the last record that was written in variable in shared memory, so which is then used on the next record to fill that field. When Postgres starts up after a clean shutdown, the variable is initialized to point ot the checkpoint record. If the system was not shut down cleanly, Postgres performs WAL recovery, the variable is initialized to point to the last replayed WAL record.

In Neon however, we can start up from any record, without performing WAL recovery. When we do that, there is no last replayed WAL record to initialize it from, and there's not real checkpoint record either - we fake the variables related to starting checkpoint. The "neon signal file" that is included in the basebackup must include an explicit LSN to use as the xl_prev value in such cases ("PREV LSN") field, and we use that.

However, that did not work correctly in versions 15 and above, when a replica was promoted immediately after startup, without replaying any records.As a result, the promoted standby wrote an end-of-WAL record with an incorrect xl_prev field, which trips over any read replicas, that are following across the switchover. It also trips over logical replication across that point. Add a test and fix it.