### PR TITLE
Replica flush dirty buffers on clean exit

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -10156,8 +10156,16 @@ CreateRestartPoint(int flags)
 			ControlFile->time = (pg_time_t) time(NULL);
 			UpdateControlFile();
 			LWLockRelease(ControlFileLock);
+			// Flush dirty buffers.
+			CheckPointBuffers(flags);
 		}
 		return false;
+	}
+
+	if (flags & CHECKPOINT_IS_SHUTDOWN)
+	{
+		// Flush dirty buffers.
+		CheckPointBuffers(flags);
 	}
 
 	/*

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -129,6 +129,7 @@ restore_running_xacts_callback_t restore_running_xacts_callback;
 set_lwlsn_db_hook_type set_lwlsn_db_hook = NULL;
 set_lwlsn_relation_hook_type set_lwlsn_relation_hook = NULL;
 set_max_lwlsn_hook_type set_max_lwlsn_hook = NULL;
+flush_dirty_buffers_hook_type flush_dirty_buffers_hook = NULL;
 
 /*
  * Number of WAL insertion locks to use. A higher value allows more insertions
@@ -10156,16 +10157,18 @@ CreateRestartPoint(int flags)
 			ControlFile->time = (pg_time_t) time(NULL);
 			UpdateControlFile();
 			LWLockRelease(ControlFileLock);
-			// Flush dirty buffers.
-			CheckPointBuffers(flags);
+
+			if (flush_dirty_buffers_hook)
+			{
+				flush_dirty_buffers_hook(flags);
+			}
 		}
 		return false;
 	}
 
-	if (flags & CHECKPOINT_IS_SHUTDOWN)
+	if (flush_dirty_buffers_hook)
 	{
-		// Flush dirty buffers.
-		CheckPointBuffers(flags);
+		flush_dirty_buffers_hook(flags);
 	}
 
 	/*

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -373,6 +373,9 @@ extern set_lwlsn_db_hook_type set_lwlsn_db_hook;
 extern set_lwlsn_relation_hook_type set_lwlsn_relation_hook;
 extern set_max_lwlsn_hook_type set_max_lwlsn_hook;
 
+typedef void (*flush_dirty_buffers_hook_type)(int flags);
+extern flush_dirty_buffers_hook_type flush_dirty_buffers_hook;
+
 extern XLogRecPtr GetRedoStartLsn(void);
 
 extern bool PromoteIsTriggered(void);


### PR DESCRIPTION
Replica does not flush dirty buffers on clean exit today.

We need it to flush dirty buffers to compare the cached content between primary & replica.