### PR TITLE
Replica flush dirty buffers on clean exit

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -153,6 +153,7 @@ restore_running_xacts_callback_t restore_running_xacts_callback;
 set_lwlsn_db_hook_type set_lwlsn_db_hook = NULL;
 set_lwlsn_relation_hook_type set_lwlsn_relation_hook = NULL;
 set_max_lwlsn_hook_type set_max_lwlsn_hook = NULL;
+flush_dirty_buffers_hook_type flush_dirty_buffers_hook = NULL;
 
 /*
  * Number of WAL insertion locks to use. A higher value allows more insertions
@@ -7222,16 +7223,17 @@ CreateRestartPoint(int flags)
 			ControlFile->state = DB_SHUTDOWNED_IN_RECOVERY;
 			UpdateControlFile();
 			LWLockRelease(ControlFileLock);
-			// Flush dirty buffers.
-			CheckPointBuffers(flags);			
+			if (flush_dirty_buffers_hook)
+			{
+				flush_dirty_buffers_hook(flags);
+			}
 		}
 		return false;
 	}
 
-	if (flags & CHECKPOINT_IS_SHUTDOWN)
+	if (flush_dirty_buffers_hook)
 	{
-		// Flush dirty buffers.
-		CheckPointBuffers(flags);
+		flush_dirty_buffers_hook(flags);
 	}
 
 	/*

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7222,8 +7222,16 @@ CreateRestartPoint(int flags)
 			ControlFile->state = DB_SHUTDOWNED_IN_RECOVERY;
 			UpdateControlFile();
 			LWLockRelease(ControlFileLock);
+			// Flush dirty buffers.
+			CheckPointBuffers(flags);			
 		}
 		return false;
+	}
+
+	if (flags & CHECKPOINT_IS_SHUTDOWN)
+	{
+		// Flush dirty buffers.
+		CheckPointBuffers(flags);
 	}
 
 	/*

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -270,6 +270,9 @@ extern set_lwlsn_db_hook_type set_lwlsn_db_hook;
 extern set_lwlsn_relation_hook_type set_lwlsn_relation_hook;
 extern set_max_lwlsn_hook_type set_max_lwlsn_hook;
 
+typedef void (*flush_dirty_buffers_hook_type)(int flags);
+extern flush_dirty_buffers_hook_type flush_dirty_buffers_hook;
+
 extern void SetRedoStartLsn(XLogRecPtr RedoStartLSN);
 extern XLogRecPtr GetRedoStartLsn(void);
 


### PR DESCRIPTION
Replica does not flush dirty buffers on clean exit today.

We need it to flush dirty buffers to compare the cached content between primary & replica.