### PR TITLE
Fix UC permissions check after CVE-2025-8713 fix

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -618,16 +618,11 @@ ExecCheckPermissions(List *rangeTable, List *rteperminfos,
 		Assert(OidIsValid(perminfo->relid));
 		result = ExecCheckOneRelPerms(perminfo);
 
-		// BEGIN HADRON
-		// If we don't have the necessary native Postgres permission,
-		// check if our Databricks OAuth token grants us permission.
-		if (!result)
-		{
-			if (ExecutorUnityCatalogCheckPerms_hook)
-				result = (*ExecutorUnityCatalogCheckPerms_hook) (perminfo);
-
-		}
-		// END HADRON
+		/* NEON: If we don't have the necessary native Postgres permission,
+		 * check if our Databricks OAUTH token grants us permission.
+		 */
+		if (!result && ExecutorUnityCatalogCheckPerms_hook)
+			result = ExecutorUnityCatalogCheckPerms_hook(perminfo);
 
 		if (!result)
 		{

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -815,6 +815,13 @@ subquery_planner(PlannerGlobal *glob, Query *parse,
 
 			perminfo = getRTEPermissionInfo(parse->rteperminfos, rte);
 			result = ExecCheckOneRelPerms(perminfo);
+
+			/* NEON: If we don't have the necessary native Postgres permission,
+			 * check if our Databricks OAUTH token grants us permission.
+			 */
+			if (!result && ExecutorUnityCatalogCheckPerms_hook)
+				result = ExecutorUnityCatalogCheckPerms_hook(perminfo);
+
 			if (!result)
 				aclcheck_error(ACLCHECK_NO_PRIV, OBJECT_VIEW,
 							   get_rel_name(perminfo->relid));


### PR DESCRIPTION
In order to fix CVE-2025-8713, Postgres added an additional location for checking access permissions of a relation. We already checked for UC permissions in ExecCheckPermissions(), but now we must add the same UC permissions check in subquery_planner().

Link: https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=a85eddab2
Link: https://www.postgresql.org/support/security/CVE-2025-8713/