### PR TITLE
Fix `-Wformat` compilation warnings on macOS

### DIFF
--- a/contrib/pg_prewarm/pg_prewarm.c
+++ b/contrib/pg_prewarm/pg_prewarm.c
@@ -12,6 +12,7 @@
  */
 #include "postgres.h"
 
+#include <inttypes.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -282,7 +283,7 @@ pg_prewarm(PG_FUNCTION_ARGS)
 			Snapshot snapshot;
 			TableScanDesc scan;
 
-			elog(LOG, "pg_prewarm: SeqScan relation \"%s\" starting %ld for %ld blocks", RelationGetRelationName(rel), first_block, last_block - first_block + 1);
+			elog(LOG, "pg_prewarm: SeqScan relation \"%s\" starting %" PRIu64 " for %" PRIu64 " blocks", RelationGetRelationName(rel), first_block, last_block - first_block + 1);
 			// Use heap scan to set hint bits on every tuple. SO_ALLOW_PAGEMODE is intentionally NOT SET.
 			// Otherwise, when a page is all visible, tuple hint bits won't be set.
 			snapshot = RegisterSnapshot(GetTransactionSnapshot());


### PR DESCRIPTION
On macOS, the build triggers the following warnings (logged as errors because of -Werror):

```
<...>/postgres-v18/contrib/pg_prewarm/pg_prewarm.c:247:111: error: format specifies type 'long' but the argument has type 'int64' (aka 'long long') [-Werror,-Wformat]
  247 |                         elog(LOG, "pg_prewarm: SeqScan relation \"%s\" starting %ld for %ld blocks", RelationGetRelationName(rel), first_block, last_block - first_block + 1);
      |                                                                                 ~~~                                                ^~~~~~~~~~~
      |                                                                                 %lld
<...>/postgres-v18/src/include/utils/elog.h:240:34: note: expanded from macro 'elog'
  240 |         ereport(elevel, errmsg_internal(__VA_ARGS__))
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Werror=unguarded-availability-new -Wendif-labels -Wmissing-format-attribute -Wcast-function-type -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-unused-command-line-argument -Wno-compound-token-split-by-macro -Wno-cast-function-type-strict -g -fsigned-char -DUSE_PREFETCH -g3  -O2 -Werror -I<...>/postgres-v17/src/interfaces/libpq -I../../../src/include -I<...>/postgres-v17/src/include -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.2.sdk -I/opt/homebrew/opt/openssl@3/include  -I/opt/homebrew/opt/openssl@3/include -I/opt/homebrew/Cellar/icu4c@78/78.1/include  -c -o pg_isready.o <...>/postgres-v17/src/bin/scripts/pg_isready.c
      |                                         ^~~~~~~~~~~
/Library/Developer/CommandLineTools/usr/bin/make -C ../../../src/interfaces/libpq all
<...>/postgres-v18/src/include/utils/elog.h:164:37: note: expanded from macro 'ereport'
  164 |         ereport_domain(elevel, TEXTDOMAIN, __VA_ARGS__)
      |                                            ^~~~~~~~~~~
<...>/postgres-v18/src/include/utils/elog.h:147:4: note: expanded from macro 'ereport_domain'
  147 |                         __VA_ARGS__, errfinish(__FILE__, __LINE__, __func__); \
      |                         ^~~~~~~~~~~
<...>/postgres-v18/contrib/pg_prewarm/pg_prewarm.c:247:124: error: format specifies type 'long' but the argument has type 'int64' (aka 'long long') [-Werror,-Wformat]
  247 |                         elog(LOG, "pg_prewarm: SeqScan relation \"%s\" starting %ld for %ld blocks", RelationGetRelationName(rel), first_block, last_block - first_block + 1);
      |                                                                                         ~~~                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                         %lld
<...>/postgres-v18/src/include/utils/elog.h:240:34: note: expanded from macro 'elog'
  240 |         ereport(elevel, errmsg_internal(__VA_ARGS__))
      |                                         ^~~~~~~~~~~
/Library/Developer/CommandLineTools/usr/bin/make -C ../../../src/backend generated-headers
<...>/postgres-v18/src/include/utils/elog.h:164:37: note: expanded from macro 'ereport'
  164 |         ereport_domain(elevel, TEXTDOMAIN, __VA_ARGS__)
      |                                            ^~~~~~~~~~~
<...>/postgres-v18/src/include/utils/elog.h:147:4: note: expanded from macro 'ereport_domain'
  147 |                         __VA_ARGS__, errfinish(__FILE__, __LINE__, __func__); \
      |                         ^~~~~~~~~~~
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Werror=unguarded-availability-new -Wendif-labels -Wmissing-format-attribute -Wcast-function-type -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-unused-command-line-argument -Wno-compound-token-split-by-macro -Wno-deprecated-non-prototype -Wno-cast-function-type-strict -g -fsigned-char -DUSE_PREFETCH -g3  -O2 -Werror -DFRONTEND -I../../../src/include -I<...>/postgres-v15/src/include -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.2.sdk -I/opt/homebrew/opt/openssl@3/include  -I/opt/homebrew/opt/openssl@3/include -I/opt/homebrew/Cellar/icu4c@78/78.1/include  -c -o seqdesc.o seqdesc.c
2 errors generated.
```