### PR TITLE
Move NEON_AUTH_TOKEN to a builtin GUC

### DIFF
--- a/src/backend/replication/libpqwalreceiver/libpqwalreceiver.c
+++ b/src/backend/replication/libpqwalreceiver/libpqwalreceiver.c
@@ -148,7 +148,6 @@ libpqrcv_connect(const char *conninfo, bool replication, bool logical,
 /* BEGIN_NEON */
 	const char *keys[7];
 	const char *vals[7];
-	char * neon_auth_token = NULL;
 /* END_NEON */
 	int			i = 0;
 
@@ -208,18 +207,21 @@ libpqrcv_connect(const char *conninfo, bool replication, bool logical,
 	vals[i] = appname;
 
 /* BEGIN_NEON */
+	/*
+	 * We use neon_storage_token for the password because conninfo strings are
+	 * limited to MAXCONNINFO in length. Our tokens encode Unity Catalog
+	 * permissions, so they can be quite lengthy.
+	 */
 	if (pg_strcasecmp(appname, "walreceiver") == 0)
 	{
-		neon_auth_token = getenv("NEON_AUTH_TOKEN");
-		if (neon_auth_token != NULL)
+		if (neon_storage_token[0] != '\0')
 		{
-			elog(LOG, "Use NEON_AUTH_TOKEN to connect");
 			keys[++i] = "password";
-			vals[i] = neon_auth_token;
+			vals[i] = neon_storage_token;
 		}
 		else
 		{
-			elog(LOG, "NEON_AUTH_TOKEN is undefined in the environment");
+			elog(LOG, "no storage token set");
 		}
 	}
 /* END_NEON */

--- a/src/backend/replication/walreceiver.c
+++ b/src/backend/replication/walreceiver.c
@@ -87,6 +87,7 @@
 int			wal_receiver_status_interval;
 int			wal_receiver_timeout;
 bool		hot_standby_feedback;
+char	   *neon_storage_token;
 
 /* libpqwalreceiver connection */
 static WalReceiverConn *wrconn = NULL;
@@ -1398,6 +1399,22 @@ WalRcvGetStateString(WalRcvState state)
 			return "stopping";
 	}
 	return "UNKNOWN";
+}
+
+/*
+ * We currently grant the privileged role pg_monitor, which implies
+ * pg_read_all_settings. Until we fix that, let's just redact the content unless
+ * the user requesting the value is a superuser.
+ *
+ * See: https://databricks.atlassian.net/browse/LKB-7128
+ */
+const char *
+show_neon_storage_token(void)
+{
+	if (superuser())
+		return neon_storage_token;
+
+	return "**********";
 }
 
 /*

--- a/src/backend/utils/misc/guc_tables.c
+++ b/src/backend/utils/misc/guc_tables.c
@@ -71,6 +71,7 @@
 #include "replication/slot.h"
 #include "replication/slotsync.h"
 #include "replication/syncrep.h"
+#include "replication/walreceiver.h"
 #include "storage/bufmgr.h"
 #include "storage/large_object.h"
 #include "storage/pg_shmem.h"
@@ -4797,6 +4798,17 @@ struct config_string ConfigureNamesString[] =
 		&restrict_nonsystem_relation_kind_string,
 		"",
 		check_restrict_nonsystem_relation_kind, assign_restrict_nonsystem_relation_kind, NULL
+	},
+
+	{
+		{"neon_storage_token", PGC_POSTMASTER, REPLICATION_STANDBY,
+			"Authentication token for Neon storage",
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NO_RESET | GUC_NO_RESET_ALL | GUC_NOT_IN_SAMPLE | GUC_SUPERUSER_ONLY
+		},
+		&neon_storage_token,
+		"",
+		NULL, NULL, show_neon_storage_token
 	},
 
 	/* End-of-list marker */

--- a/src/include/replication/walreceiver.h
+++ b/src/include/replication/walreceiver.h
@@ -29,6 +29,7 @@
 extern PGDLLIMPORT int wal_receiver_status_interval;
 extern PGDLLIMPORT int wal_receiver_timeout;
 extern PGDLLIMPORT bool hot_standby_feedback;
+extern PGDLLIMPORT char *neon_storage_token;
 
 /*
  * MAXCONNINFO: maximum size of a connection string.
@@ -486,6 +487,8 @@ walrcv_clear_result(WalRcvExecResult *walres)
 extern void WalReceiverMain(char *startup_data, size_t startup_data_len) pg_attribute_noreturn();
 extern void ProcessWalRcvInterrupts(void);
 extern void WalRcvForceReply(void);
+
+extern const char *show_neon_storage_token(void);
 
 /* prototypes for functions in walreceiverfuncs.c */
 extern Size WalRcvShmemSize(void);


### PR DESCRIPTION
This environment variable is used as the password to connect to another postgres instance as the walreceiver. The purpose of moving to a GUC is so that we can reload the storage auth token periodically.