### PR TITLE
Add PG18 logical slot persistence hooks

### DIFF
--- a/src/backend/replication/slot.c
+++ b/src/backend/replication/slot.c
@@ -59,6 +59,10 @@
 #include "utils/guc_hooks.h"
 #include "utils/injection_point.h"
 #include "utils/varlena.h"
+#include "replication/logical_slots_store.h"
+
+/* NEON: Hook for storing logical slot state - implemented by neon extension */
+logical_slots_store_hook_type logical_slots_store_hook = NULL;
 
 /*
  * Replication slot on-disk data structure.
@@ -2449,6 +2453,12 @@ SaveSlotToPath(ReplicationSlot *slot, const char *dir, int elevel)
 	slot->last_saved_confirmed_flush = cp.slotdata.confirmed_flush;
 	slot->last_saved_restart_lsn = cp.slotdata.restart_lsn;
 	SpinLockRelease(&slot->mutex);
+
+	/*
+	 * NEON: Store to external storage while holding io_in_progress_lock.
+	 */
+	if (logical_slots_store_hook != NULL)
+		logical_slots_store_hook(dir, &cp.slotdata);
 
 	LWLockRelease(&slot->io_in_progress_lock);
 }

--- a/src/include/replication/logical_slots_store.h
+++ b/src/include/replication/logical_slots_store.h
@@ -1,0 +1,24 @@
+/*-------------------------------------------------------------------------
+ *
+ * logical_slots_store.h
+ *	  Logical replication slot state persistence
+ *
+ * IDENTIFICATION
+ *	  src/include/replication/logical_slots_store.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef LOGICAL_SLOTS_STORE_H
+#define LOGICAL_SLOTS_STORE_H
+
+#include "replication/slot.h"
+
+/* Hook for storing logical slot state */
+typedef void (*logical_slots_store_hook_type) (const char *dir, ReplicationSlotPersistentData *saved_data);
+extern PGDLLIMPORT logical_slots_store_hook_type logical_slots_store_hook;
+
+/* Extension function - called by the hook */
+extern void store_logical_slots_state(const char *dir, ReplicationSlotPersistentData *saved_data);
+
+#endif							/* LOGICAL_SLOTS_STORE_H */
+


### PR DESCRIPTION
Add corresponding PG18 hooks for persisting logical slots on replicas. See https://github.com/databricks-eng/hadron/pull/3207.