### PR TITLE
[LKB-5974][PG_18] Add the ability to reduce FPI

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -863,6 +863,10 @@ XLogInsertRecord(XLogRecData *rdata,
 		 * our local copy but not force a recomputation.  (If doPageWrites was
 		 * just turned off, we could recompute the record without full pages,
 		 * but we choose not to bother.)
+		 *
+		 * However, if suppress_fpi is true, we skip the recomputation check
+		 * since we're deliberately suppressing full page images for this
+		 * record via the FPI control hook.
 		 */
 		if (RedoRecPtr != Insert->RedoRecPtr)
 		{
@@ -873,7 +877,8 @@ XLogInsertRecord(XLogRecData *rdata,
 
 		if (doPageWrites &&
 			(!prevDoPageWrites ||
-			 (fpw_lsn != InvalidXLogRecPtr && fpw_lsn <= RedoRecPtr)))
+			 (!suppress_fpi &&
+			  fpw_lsn != InvalidXLogRecPtr && fpw_lsn <= RedoRecPtr)))
 		{
 			/*
 			 * Oops, some buffer now needs to be backed up that the caller

--- a/src/backend/access/transam/xloginsert.c
+++ b/src/backend/access/transam/xloginsert.c
@@ -94,6 +94,12 @@ int			max_replication_apply_lag;
 int			max_replication_flush_lag;
 int			max_replication_write_lag;
 
+/* NEON: Hook to determine if FPI should be suppressed for a WAL record */
+xlog_should_suppress_fpi_hook_type xlog_should_suppress_fpi_hook = NULL;
+
+/* NEON: Global flag to suppress FPI for current WAL record */
+bool suppress_fpi = false;
+
 static registered_buffer *registered_buffers;
 static int	max_registered_buffers; /* allocated size */
 static int	max_registered_block_id = 0;	/* highest block_id + 1 currently
@@ -530,6 +536,16 @@ XLogInsert(RmgrId rmid, uint8 info)
 		 */
 		GetFullPageWriteInfo(&RedoRecPtr, &doPageWrites);
 
+		/*
+		 * NEON: Check if we should suppress FPI for this WAL record.
+		 */
+		suppress_fpi = false;
+		if (xlog_should_suppress_fpi_hook != NULL) {
+			suppress_fpi = xlog_should_suppress_fpi_hook();
+			elog(DEBUG1, "FPI suppress hook called: suppress_fpi=%d, doPageWrites=%d",
+				suppress_fpi, doPageWrites);
+		}
+
 		rdt = XLogRecordAssemble(rmid, info, RedoRecPtr, doPageWrites,
 								 &fpw_lsn, &num_fpi, &topxid_included);
 
@@ -630,9 +646,17 @@ XLogRecordAssemble(RmgrId rmid, uint8 info,
 			 */
 			XLogRecPtr	page_lsn = PageGetLSN(regbuf->page);
 
-			needs_backup = (page_lsn <= RedoRecPtr);
+			if (suppress_fpi)
+				needs_backup = false;
+			else
+				needs_backup = (page_lsn <= RedoRecPtr);
+
 			if (!needs_backup)
 			{
+				/*
+				 * Set fpw_lsn to signal that this record should be
+				 * recomputed if doPageWrites changes.
+				 */
 				if (*fpw_lsn == InvalidXLogRecPtr || page_lsn < *fpw_lsn)
 					*fpw_lsn = page_lsn;
 			}

--- a/src/backend/access/transam/xloginsert.c
+++ b/src/backend/access/transam/xloginsert.c
@@ -635,7 +635,7 @@ XLogRecordAssemble(RmgrId rmid, uint8 info,
 			needs_backup = true;
 		else if (regbuf->flags & REGBUF_NO_IMAGE)
 			needs_backup = false;
-		else if (!doPageWrites)
+		else if (!doPageWrites || suppress_fpi)
 			needs_backup = false;
 		else
 		{
@@ -646,10 +646,7 @@ XLogRecordAssemble(RmgrId rmid, uint8 info,
 			 */
 			XLogRecPtr	page_lsn = PageGetLSN(regbuf->page);
 
-			if (suppress_fpi)
-				needs_backup = false;
-			else
-				needs_backup = (page_lsn <= RedoRecPtr);
+			needs_backup = (page_lsn <= RedoRecPtr);
 
 			if (!needs_backup)
 			{

--- a/src/include/access/xloginsert.h
+++ b/src/include/access/xloginsert.h
@@ -44,6 +44,16 @@ extern int max_replication_apply_lag;
 extern int max_replication_flush_lag;
 extern int max_replication_write_lag;
 
+/* NEON: Hook to determine if FPI should be suppressed for a WAL record
+ * Returns true to suppress FPI, false to allow FPI
+ * Applies to all resource managers for checkpoint-based FPI triggers.
+ */
+typedef bool (*xlog_should_suppress_fpi_hook_type)(void);
+extern PGDLLIMPORT xlog_should_suppress_fpi_hook_type xlog_should_suppress_fpi_hook;
+
+/* NEON: Flag set per-record to suppress FPI (set by xlog_should_suppress_fpi_hook) */
+extern bool suppress_fpi;
+
 /* prototypes for public functions in xloginsert.c: */
 extern void XLogBeginInsert(void);
 extern void XLogSetRecordFlags(uint8 flags);


### PR DESCRIPTION
# Context 

**Why is a full page image(FPI) unnecessary in Lakebase/Neon?** 

In vanilla PostgreSQL, full-page images (FPIs) are required to guard against torn page writes caused by non-atomic 8 KB page writes to local storage.
However, in the Lakehouse/Neon architecture, FPIs are generally not needed because the compute node never overwrites pages in place. Instead, all modifications are logged as WAL records and sent to the pageserver, which appends them into the storage layer’s log-structured layout. Since there is no local data-file page overwriting, the torn-page risk that FPIs protect against does not exist on the compute node’s local storage.

**Why do we want to reduce the full page image?** 

Full-page images amplify every small update into an 8 KB WAL write, which drives up WAL volume and causes Reverse ETL ingestion to hit the max_wal_rate limit in Serverless Lakebase.

**Why not eliminate full-page images entirely?**
Full-page images help the pageserver reduce read-path I/O by providing complete page snapshots that can be used during page reconstruction. Removing FPIs entirely could negatively impact read performance.

# Summary
This PR(along with the hadron PR: https://github.com/databricks-eng/hadron/pull/3155 )implements reducing FPI to improve write performance for data ingestion workloads, specifically reverse ETL and Spark streaming use cases. The feature is opt-in per table to avoid unintended impact on other customers. 

## Performance Impact
Testing shows 3.75x write throughput improvement without significantly impacting read performance. See [performance analysis.
](https://docs.google.com/document/d/19yY8nogB5hTjXmAsX-5GT4LVDNX3c86_gK2Y6Fu7TTw/edit?tab=t.quizviqwhqh0#heading=h.kw4pwpzifs9u)

# Major changes 
## Probabilistic reducing  FPI generation to 5% 

Added `neon_should_suppress_fpi` which will randomly determine if we should suppress FPI with a default value of 5%.  The 5% is chosen to: 
- Significantly reducing WAL volume to avoid write-amplification bottlenecks.
- Retaining a small number of FPIs so the pageserver still benefits from occasional full-page snapshots, helping maintain efficient read-path performance.




