### PR TITLE
OPtimize storing zero page image in WAL as FPI

### DIFF
--- a/src/backend/access/transam/xloginsert.c
+++ b/src/backend/access/transam/xloginsert.c
@@ -638,22 +638,30 @@ XLogRecordAssemble(RmgrId rmid, uint8 info,
 			 */
 			if (regbuf->flags & REGBUF_STANDARD)
 			{
-				/* Assume we can omit data between pd_lower and pd_upper */
-				uint16		lower = ((PageHeader) page)->pd_lower;
-				uint16		upper = ((PageHeader) page)->pd_upper;
-
-				if (lower >= SizeOfPageHeaderData &&
-					upper > lower &&
-					upper <= BLCKSZ)
+				if (PageIsNew(page))
 				{
-					bimg.hole_offset = lower;
-					cbimg.hole_length = upper - lower;
+					bimg.hole_offset = 0;
+					cbimg.hole_length = BLCKSZ;
 				}
 				else
 				{
-					/* No "hole" to remove */
-					bimg.hole_offset = 0;
-					cbimg.hole_length = 0;
+					/* Assume we can omit data between pd_lower and pd_upper */
+					uint16		lower = ((PageHeader) page)->pd_lower;
+					uint16		upper = ((PageHeader) page)->pd_upper;
+
+					if (lower >= SizeOfPageHeaderData &&
+						upper > lower &&
+						upper <= BLCKSZ)
+					{
+						bimg.hole_offset = lower;
+						cbimg.hole_length = upper - lower;
+					}
+					else
+					{
+						/* No "hole" to remove */
+						bimg.hole_offset = 0;
+						cbimg.hole_length = 0;
+					}
 				}
 			}
 			else

--- a/src/backend/access/transam/xlogreader.c
+++ b/src/backend/access/transam/xlogreader.c
@@ -1873,7 +1873,9 @@ DecodeXLogRecord(XLogReaderState *state,
 				if ((blk->bimg_info & BKPIMAGE_HAS_HOLE) &&
 					(blk->hole_offset == 0 ||
 					 blk->hole_length == 0 ||
-					 blk->bimg_len == BLCKSZ))
+					 blk->bimg_len == BLCKSZ) &&
+					!(blk->hole_offset == 0 &&
+					  blk->hole_length == BLCKSZ)) /* null page */
 				{
 					report_invalid_record(state,
 										  "BKPIMAGE_HAS_HOLE set, but hole offset %u length %u block image length %u at %X/%X",


### PR DESCRIPTION
PG>=16 has optimization for storing zero page in FPI. When storing page as FPIN in WAL records, Postgres excludes page hole (space betweenpd_upper and pd_lower), but it not able to handle zero page (hole size=page size).
It allows to minimize WAL size in case of walloging smgrzeroextend.
PG14/15 doesn't have smgrzeroextend and so has not such optimization.
