### PR TITLE
Add wait event hooks for extensions

### DIFF
--- a/src/backend/utils/activity/wait_event.c
+++ b/src/backend/utils/activity/wait_event.c
@@ -37,6 +37,9 @@ static const char *pgstat_get_wait_io(WaitEventIO w);
 static uint32 local_my_wait_event_info;
 uint32	   *my_wait_event_info = &local_my_wait_event_info;
 
+pgstat_report_wait_start_hook_type pgstat_report_wait_start_hook = NULL;
+pgstat_report_wait_end_hook_type pgstat_report_wait_end_hook = NULL;
+
 
 /*
  * Configure wait event reporting to report wait events to *wait_event_info.

--- a/src/include/utils/wait_event.h
+++ b/src/include/utils/wait_event.h
@@ -249,6 +249,11 @@ extern void pgstat_reset_wait_event_storage(void);
 
 extern PGDLLIMPORT uint32 *my_wait_event_info;
 
+typedef void (*pgstat_report_wait_start_hook_type)(uint32 wait_event_info);
+extern PGDLLIMPORT pgstat_report_wait_start_hook_type pgstat_report_wait_start_hook;
+typedef void (*pgstat_report_wait_end_hook_type)(uint32 wait_event_info);
+extern PGDLLIMPORT pgstat_report_wait_end_hook_type pgstat_report_wait_end_hook;
+
 
 /* ----------
  * pgstat_report_wait_start() -
@@ -277,6 +282,9 @@ pgstat_report_wait_start(uint32 wait_event_info)
 	 * four-bytes, updates are atomic.
 	 */
 	*(volatile uint32 *) my_wait_event_info = wait_event_info;
+
+	if (pgstat_report_wait_start_hook)
+		pgstat_report_wait_start_hook(wait_event_info);
 }
 
 /* ----------
@@ -288,6 +296,9 @@ pgstat_report_wait_start(uint32 wait_event_info)
 static inline void
 pgstat_report_wait_end(void)
 {
+	if (pgstat_report_wait_end_hook)
+		pgstat_report_wait_end_hook(*(volatile uint32 *) my_wait_event_info);
+
 	/* see pgstat_report_wait_start() */
 	*(volatile uint32 *) my_wait_event_info = 0;
 }


### PR DESCRIPTION
Add hooks that are called when wait events start and end:
- pgstat_report_wait_start_hook - called in pgstat_report_wait_start()
- pgstat_report_wait_end_hook - called in pgstat_report_wait_end()

These hooks enable extensions to collect wait event statistics. Backported from the PG17 version of this patch.