### PR TITLE
Add wait event hooks for extensions

### DIFF
--- a/src/backend/utils/activity/wait_event.c
+++ b/src/backend/utils/activity/wait_event.c
@@ -43,6 +43,9 @@ uint32	   *my_wait_event_info = &local_my_wait_event_info;
 #define WAIT_EVENT_CLASS_MASK	0xFF000000
 #define WAIT_EVENT_ID_MASK		0x0000FFFF
 
+pgstat_report_wait_start_hook_type pgstat_report_wait_start_hook = NULL;
+pgstat_report_wait_end_hook_type pgstat_report_wait_end_hook = NULL;
+
 /*
  * Hash tables for storing custom wait event ids and their names in
  * shared memory.

--- a/src/include/utils/wait_event.h
+++ b/src/include/utils/wait_event.h
@@ -38,6 +38,11 @@ extern void pgstat_reset_wait_event_storage(void);
 
 extern PGDLLIMPORT uint32 *my_wait_event_info;
 
+typedef void (*pgstat_report_wait_start_hook_type)(uint32 wait_event_info);
+extern PGDLLIMPORT pgstat_report_wait_start_hook_type pgstat_report_wait_start_hook;
+typedef void (*pgstat_report_wait_end_hook_type)(uint32 wait_event_info);
+extern PGDLLIMPORT pgstat_report_wait_end_hook_type pgstat_report_wait_end_hook;
+
 
 /*
  * Wait Events - Extension, InjectionPoint
@@ -89,6 +94,9 @@ pgstat_report_wait_start(uint32 wait_event_info)
 	 * four-bytes, updates are atomic.
 	 */
 	*(volatile uint32 *) my_wait_event_info = wait_event_info;
+
+	if (pgstat_report_wait_start_hook)
+		pgstat_report_wait_start_hook(wait_event_info);
 }
 
 /* ----------
@@ -100,6 +108,9 @@ pgstat_report_wait_start(uint32 wait_event_info)
 static inline void
 pgstat_report_wait_end(void)
 {
+	if (pgstat_report_wait_end_hook)
+		pgstat_report_wait_end_hook(*(volatile uint32 *) my_wait_event_info);
+
 	/* see pgstat_report_wait_start() */
 	*(volatile uint32 *) my_wait_event_info = 0;
 }


### PR DESCRIPTION
Add hooks that are called when wait events start and end:
- pgstat_report_wait_start_hook - called in pgstat_report_wait_start()
- pgstat_report_wait_end_hook - called in pgstat_report_wait_end()

These hooks enable extensions to collect wait event statistics.