### PR TITLE
Move the neon_storage_token GUC definition to the neon extension

### DIFF
--- a/src/backend/replication/libpqwalreceiver/libpqwalreceiver.c
+++ b/src/backend/replication/libpqwalreceiver/libpqwalreceiver.c
@@ -216,14 +216,10 @@ libpqrcv_connect(const char *conninfo, bool replication, bool logical,
 	 */
 	if (pg_strcasecmp(appname, "walreceiver") == 0)
 	{
-		if (neon_storage_token[0] != '\0')
+		if (neon_storage_token && neon_storage_token[0] != '\0')
 		{
 			keys[++i] = "password";
 			vals[i] = neon_storage_token;
-		}
-		else
-		{
-			elog(LOG, "no storage token set");
 		}
 	}
 /* END_NEON */

--- a/src/backend/replication/walreceiver.c
+++ b/src/backend/replication/walreceiver.c
@@ -1394,22 +1394,6 @@ WalRcvGetStateString(WalRcvState state)
 }
 
 /*
- * We currently grant the privileged role pg_monitor, which implies
- * pg_read_all_settings. Until we fix that, let's just redact the content unless
- * the user requesting the value is a superuser.
- *
- * See: https://databricks.atlassian.net/browse/LKB-7128
- */
-const char *
-show_neon_storage_token(void)
-{
-	if (superuser())
-		return neon_storage_token;
-
-	return "**********";
-}
-
-/*
  * Returns activity of WAL receiver, including pid, state and xlog locations
  * received from the WAL sender of another server.
  */

--- a/src/backend/utils/misc/guc_tables.c
+++ b/src/backend/utils/misc/guc_tables.c
@@ -5051,17 +5051,6 @@ struct config_string ConfigureNamesString[] =
 		check_log_connections, assign_log_connections, NULL
 	},
 
-	{
-		{"neon_storage_token", PGC_SUSET, REPLICATION_STANDBY,
-			"Authentication token for Neon storage",
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NO_RESET | GUC_NO_RESET_ALL | GUC_NOT_IN_SAMPLE | GUC_SUPERUSER_ONLY
-		},
-		&neon_storage_token,
-		"",
-		NULL, NULL, show_neon_storage_token,
-	},
-
 
 	/* End-of-list marker */
 	{

--- a/src/include/replication/walreceiver.h
+++ b/src/include/replication/walreceiver.h
@@ -490,8 +490,6 @@ walrcv_clear_result(WalRcvExecResult *walres)
 pg_noreturn extern void WalReceiverMain(const void *startup_data, size_t startup_data_len);
 extern void WalRcvForceReply(void);
 
-extern const char *show_neon_storage_token(void);
-
 /* prototypes for functions in walreceiverfuncs.c */
 extern Size WalRcvShmemSize(void);
 extern void WalRcvShmemInit(void);


### PR DESCRIPTION
This is exactly what we do for privileged_role_name. It reduces the amount of changes in the fork.