### PR TITLE
Move the neon_storage_token GUC definition to the neon extension

### DIFF
--- a/src/backend/replication/libpqwalreceiver/libpqwalreceiver.c
+++ b/src/backend/replication/libpqwalreceiver/libpqwalreceiver.c
@@ -163,14 +163,10 @@ libpqrcv_connect(const char *conninfo, bool logical, bool must_use_password,
 	 */
 	if (pg_strcasecmp(appname, "walreceiver") == 0)
 	{
-		if (neon_storage_token[0] != '\0')
+		if (neon_storage_token && neon_storage_token[0] != '\0')
 		{
 			keys[++i] = "password";
 			vals[i] = neon_storage_token;
-		}
-		else
-		{
-			elog(LOG, "no storage token set");
 		}
 	}
 /* END_NEON */

--- a/src/backend/replication/walreceiver.c
+++ b/src/backend/replication/walreceiver.c
@@ -1397,22 +1397,6 @@ WalRcvGetStateString(WalRcvState state)
 }
 
 /*
- * We currently grant the privileged role pg_monitor, which implies
- * pg_read_all_settings. Until we fix that, let's just redact the content unless
- * the user requesting the value is a superuser.
- *
- * See: https://databricks.atlassian.net/browse/LKB-7128
- */
-const char *
-show_neon_storage_token(void)
-{
-	if (superuser())
-		return neon_storage_token;
-
-	return "**********";
-}
-
-/*
  * Returns activity of WAL receiver, including pid, state and xlog locations
  * received from the WAL sender of another server.
  */

--- a/src/backend/utils/misc/guc_tables.c
+++ b/src/backend/utils/misc/guc_tables.c
@@ -4640,18 +4640,6 @@ struct config_string ConfigureNamesString[] =
 		check_restrict_nonsystem_relation_kind, assign_restrict_nonsystem_relation_kind, NULL
 	},
 
-
-	{
-		{"neon_storage_token", PGC_SUSET, REPLICATION_STANDBY,
-			"Authentication token for Neon storage",
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NO_RESET | GUC_NO_RESET_ALL | GUC_NOT_IN_SAMPLE | GUC_SUPERUSER_ONLY
-		},
-		&neon_storage_token,
-		"",
-		NULL, NULL, show_neon_storage_token
-	},
-
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, NULL, NULL, NULL, NULL

--- a/src/include/replication/walreceiver.h
+++ b/src/include/replication/walreceiver.h
@@ -462,8 +462,6 @@ extern void WalReceiverMain(void) pg_attribute_noreturn();
 extern void ProcessWalRcvInterrupts(void);
 extern void WalRcvForceReply(void);
 
-extern const char *show_neon_storage_token(void);
-
 /* prototypes for functions in walreceiverfuncs.c */
 extern Size WalRcvShmemSize(void);
 extern void WalRcvShmemInit(void);


### PR DESCRIPTION
This is exactly what we do for privileged_role_name. It reduces the amount of changes in the fork.