### PR TITLE
pgbench: Fix compiler warnings introduced in 65d8de10869

### DIFF
--- a/src/bin/pgbench/pgbench.c
+++ b/src/bin/pgbench/pgbench.c
@@ -1670,7 +1670,7 @@ addOverflowValue(LatencyHistogram *hist, double latency_us)
 static void
 addToLatencyHistogram(LatencyHistogram *hist, double latency_us)
 {
-	int			bucket;
+	int			bucket = 0;
 	int			tier_offset = 0;
 	int64		range_start = 0;
 	int			t;
@@ -7822,8 +7822,6 @@ main(int argc, char **argv)
 	 */
 	if (report_percentiles && report_per_command)
 	{
-		int			total_commands = 0;
-
 		for (i = 0; i < num_scripts; i++)
 		{
 			Command   **commands = sql_script[i].commands;
@@ -7832,7 +7830,6 @@ main(int argc, char **argv)
 			{
 				commands[j]->latency_hist = (LatencyHistogram *) pg_malloc(sizeof(LatencyHistogram));
 				initLatencyHistogram(commands[j]->latency_hist);
-				total_commands++;
 			}
 		}
 	}


### PR DESCRIPTION
Fix two compiler warnings in pgbench.c:
- Initialize bucket variable to silence -Wsometimes-uninitialized
- Remove unused total_commands variable to silence -Wunused-but-set-variable

These warnings were introduced by commit 65d8de10869 which added latency percentile reporting with histogram-based tracking.