### PR TITLE
pgbench: fix `-Wsometimes-uninitialized` and `-Wunused-but-set-variable` (v17)

### DIFF
--- a/src/bin/pgbench/pgbench.c
+++ b/src/bin/pgbench/pgbench.c
@@ -7789,8 +7789,6 @@ main(int argc, char **argv)
 	 */
 	if (report_percentiles && report_per_command)
 	{
-		int			total_commands = 0;
-
 		for (i = 0; i < num_scripts; i++)
 		{
 			Command   **commands = sql_script[i].commands;
@@ -7799,7 +7797,6 @@ main(int argc, char **argv)
 			{
 				commands[j]->latency_hist = (LatencyHistogram *) pg_malloc(sizeof(LatencyHistogram));
 				initLatencyHistogram(commands[j]->latency_hist);
-				total_commands++;
 			}
 		}
 	}

--- a/src/bin/pgbench/pgbench.c
+++ b/src/bin/pgbench/pgbench.c
@@ -1643,7 +1643,7 @@ addOverflowValue(LatencyHistogram *hist, double latency_us)
 static void
 addToLatencyHistogram(LatencyHistogram *hist, double latency_us)
 {
-	int			bucket;
+	int			bucket = 0;
 	int			tier_offset = 0;
 	int64		range_start = 0;
 	int			t;


### PR DESCRIPTION
This PR fixed the following compilation warnings (found on macOS)

```
.../postgres-v17/src/bin/pgbench/pgbench.c:1657:14: warning: variable 'bucket' is used uninitialized whenever 'for' loop exits because its condition is false [-Wsometimes-uninitialized]
 1657 |         for (t = 0; t < LATENCY_HIST_NUM_TIERS; t++)
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~
.../postgres-v17/src/bin/pgbench/pgbench.c:1681:16: note: uninitialized use occurs here
 1681 |         hist->buckets[bucket]++;
      |                       ^~~~~~
/Users/alexander.bayandin/work/neon-main//vendor/postgres-v17/src/bin/pgbench/pgbench.c:1657:14: note: remove the condition if it is always true
 1657 |         for (t = 0; t < LATENCY_HIST_NUM_TIERS; t++)
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~
.../postgres-v17/src/bin/pgbench/pgbench.c:1646:14: note: initialize the variable 'bucket' to silence this warning
 1646 |         int                     bucket;
      |                                       ^
      |                                        = 0
.../postgres-v17/src/bin/pgbench/pgbench.c:7792:9: warning: variable 'total_commands' set but not used [-Wunused-but-set-variable]
 7792 |                 int                     total_commands = 0;
      |                                         ^
2 warnings generated.
```