### PR TITLE
pgbench: fix `-Wsometimes-uninitialized` and `-Wunused-but-set-variable` (v18)

### DIFF
--- a/src/bin/pgbench/pgbench.c
+++ b/src/bin/pgbench/pgbench.c
@@ -7822,8 +7822,6 @@ main(int argc, char **argv)
 	 */
 	if (report_percentiles && report_per_command)
 	{
-		int			total_commands = 0;
-
 		for (i = 0; i < num_scripts; i++)
 		{
 			Command   **commands = sql_script[i].commands;
@@ -7832,7 +7830,6 @@ main(int argc, char **argv)
 			{
 				commands[j]->latency_hist = (LatencyHistogram *) pg_malloc(sizeof(LatencyHistogram));
 				initLatencyHistogram(commands[j]->latency_hist);
-				total_commands++;
 			}
 		}
 	}

--- a/src/bin/pgbench/pgbench.c
+++ b/src/bin/pgbench/pgbench.c
@@ -1670,7 +1670,7 @@ addOverflowValue(LatencyHistogram *hist, double latency_us)
 static void
 addToLatencyHistogram(LatencyHistogram *hist, double latency_us)
 {
-	int			bucket;
+	int			bucket = 0;
 	int			tier_offset = 0;
 	int64		range_start = 0;
 	int			t;


### PR DESCRIPTION
This PR fixed the following compilation warnings (found on macOS)

```
.../postgres-v18/src/bin/pgbench/pgbench.c:1684:14: warning: variable 'bucket' is used uninitialized whenever 'for' loop exits because its condition is false [-Wsometimes-uninitialized]
 1684 |         for (t = 0; t < LATENCY_HIST_NUM_TIERS; t++)
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~
.../postgres-v18/src/bin/pgbench/pgbench.c:1708:16: note: uninitialized use occurs here
 1708 |         hist->buckets[bucket]++;
      |                       ^~~~~~
.../postgres-v18/src/bin/pgbench/pgbench.c:1684:14: note: remove the condition if it is always true
 1684 |         for (t = 0; t < LATENCY_HIST_NUM_TIERS; t++)
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~
.../postgres-v18/src/bin/pgbench/pgbench.c:1673:14: note: initialize the variable 'bucket' to silence this warning
 1673 |         int                     bucket;
      |                                       ^
      |                                        = 0
.../postgres-v18/src/bin/pgbench/pgbench.c:7825:9: warning: variable 'total_commands' set but not used [-Wunused-but-set-variable]
 7825 |                 int                     total_commands = 0;
      |                                         ^
2 warnings generated.
```