### PR TITLE
Fix OOB in log_newpage_range

### DIFF
--- a/src/backend/access/transam/xloginsert.c
+++ b/src/backend/access/transam/xloginsert.c
@@ -35,7 +35,6 @@
 #include "common/pg_lzcompress.h"
 #include "miscadmin.h"
 #include "pg_trace.h"
-#include "storage/buf_internals.h"
 #include "replication/origin.h"
 #include "replication/walsender.h"
 #include "storage/bufmgr.h"
@@ -1359,23 +1358,7 @@ log_newpage_range(Relation rel, ForkNumber forknum,
 			if (!PageIsNew(BufferGetPage(buf)))
 				bufpack[nbufs++] = buf;
 			else
-			{
-				BufferDesc *bufdesc;
-
-				bufdesc = GetBufferDescriptor(buf);
-
-				/* only operate on  operations on non-permanent buffers */
-				if ((pg_atomic_read_u32(&bufdesc->state) & BM_PERMANENT) == 0)
-				{
-					/* We have the exclusive content lock on the page, so no concurrent
-					 * writer can be accessing this page */
-					uint32 buf_state = LockBufHdr(bufdesc);
-					buf_state |= BM_PERMANENT;
-					UnlockBufHdr(bufdesc, buf_state);
-				}
-
 				UnlockReleaseBuffer(buf);
-			}
 			blkno++;
 		}
 
@@ -1394,31 +1377,6 @@ log_newpage_range(Relation rel, ForkNumber forknum,
 		}
 
 		recptr = XLogInsert(RM_XLOG_ID, XLOG_FPI);
-
-		/*
-		 * Mark the buffers as permanent, if they weren't already marked PERMANENT.
-		 *
-		 * Note that this does not race with concurrent writes, because those
-		 * can not start while the page is exclusively locked by this backend.
-		 */
-		for (i = 0; i < nbufs; i++)
-		{
-			BufferDesc *bufdesc;
-			uint32		buf_state;
-
-			bufdesc = GetBufferDescriptor(bufpack[i] - 1);
-
-			/* skip operations on already-permanent buffers */
-			if (pg_atomic_read_u32(&bufdesc->state) & BM_PERMANENT)
-				continue;
-
-			/* we have the exclusive content lock on the page, so this is safe */
-			buf_state = LockBufHdr(bufdesc);
-			buf_state |= BM_PERMANENT;
-			UnlockBufHdr(bufdesc, buf_state);
-
-			Assert(pg_atomic_read_u32(&bufdesc->state) & BM_PERMANENT);
-		}
 
 		for (i = 0; i < nbufs; i++)
 		{


### PR DESCRIPTION
See https://databricks.slack.com/archives/C092W8NBXC0/p1768911662770739
and https://databricks.atlassian.net/browse/LKB-8536

Commit 3750bd51f7a1 (PG18 port to Neon) adds to `log_newpages_range` function code which force setting of `BM_PERMANENT` flag. This code
1. contains bug (OOB)
2. is redundant (bit is already set by Postgres)
3. is useless - right now presence of this flag can not somehow affect performance

So undo this changes.