### PR TITLE
Add get_pin_limit_hook

### DIFF
--- a/src/backend/storage/buffer/bufmgr.c
+++ b/src/backend/storage/buffer/bufmgr.c
@@ -66,6 +66,7 @@
 #include "utils/resowner.h"
 #include "utils/timestamp.h"
 
+uint32 (*get_pin_limit_hook)(void);
 
 /* Note: these two macros only work on shared buffers, not local ones! */
 #define BufHdrGetBlock(bufHdr)	((Block) (BufferBlocks + ((Size) (bufHdr)->buf_id) * BLCKSZ))
@@ -2131,7 +2132,7 @@ LimitAdditionalPins(uint32 *additional_pins)
 		return;
 
 	max_backends = MaxBackends + NUM_AUXILIARY_PROCS;
-	max_proportional_pins = NBuffers / max_backends;
+	max_proportional_pins = get_pin_limit_hook ? get_pin_limit_hook() : NBuffers / max_backends;
 
 	/*
 	 * Subtract the approximate number of buffers already pinned by this

--- a/src/include/storage/bufmgr.h
+++ b/src/include/storage/bufmgr.h
@@ -325,6 +325,7 @@ extern int	GetAccessStrategyPinLimit(BufferAccessStrategy strategy);
 
 extern void FreeAccessStrategy(BufferAccessStrategy strategy);
 
+extern uint32 (*get_pin_limit_hook)(void);
 
 /* inline functions */
 


### PR DESCRIPTION
Define get_pin_limit_hook to prevent too small prefetch distance in case of large max_connections.