### PR TITLE
Prevent possible search_path attacks

### DIFF
--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -4262,12 +4262,16 @@ finalNamespacePath(List *oidlist, Oid *firstNS)
 	 * the front, not the back; also notice that we do not check USAGE
 	 * permissions for these.
 	 */
-	if (!list_member_oid(finalPath, PG_CATALOG_NAMESPACE) || prohibit_superuser_overrides)
+	if (!list_member_oid(finalPath, PG_CATALOG_NAMESPACE))
 		finalPath = lcons_oid(PG_CATALOG_NAMESPACE, finalPath);
 
 	if (OidIsValid(myTempNamespace) &&
 		!list_member_oid(finalPath, myTempNamespace))
 		finalPath = lcons_oid(myTempNamespace, finalPath);
+
+	/* Always place pg_catalog at the beginning of search path */
+	if (prohibit_superuser_overrides && superuser())
+		finalPath = lcons_oid(PG_CATALOG_NAMESPACE, finalPath);
 
 	return finalPath;
 }

--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -210,7 +210,7 @@ static SubTransactionId myTempNamespaceSubID = InvalidSubTransactionId;
  * of the GUC variable 'search_path'.
  */
 char	   *namespace_search_path = NULL;
-bool		prohibit_superuser_overrides;
+bool		prohibit_superuser_overrides = true;
 
 /* Local functions */
 static bool RelationIsVisibleExt(Oid relid, bool *is_missing);

--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -210,7 +210,7 @@ static SubTransactionId myTempNamespaceSubID = InvalidSubTransactionId;
  * of the GUC variable 'search_path'.
  */
 char	   *namespace_search_path = NULL;
-
+bool		prohibit_superuser_overrides;
 
 /* Local functions */
 static bool RelationIsVisibleExt(Oid relid, bool *is_missing);
@@ -1201,6 +1201,7 @@ FuncnameGetCandidates(List *names, int nargs, List *argnames,
 	Oid			namespaceId;
 	CatCList   *catlist;
 	int			i;
+	bool		has_superuser_candidate = false;
 
 	/* check for caller error */
 	Assert(nargs >= 0 || !(expand_variadic | expand_defaults));
@@ -1262,6 +1263,22 @@ FuncnameGetCandidates(List *names, int nargs, List *argnames,
 			}
 			if (nsp == NULL)
 				continue;		/* proc is not in search path */
+		}
+
+		/* prohibit overrides under superuser */
+		if (prohibit_superuser_overrides && superuser())
+		{
+			bool owned_by_superuser = superuser_arg(procform->proowner);
+
+			/* If we have superuser condidate, then ignore all non-supoeruser alternatives */
+			if (resultList && has_superuser_candidate && !owned_by_superuser)
+				continue;
+
+			/* If new candidate is owned by superuser then forget all non-superuser candidates */
+			if (owned_by_superuser && !has_superuser_candidate)
+				resultList = NULL;
+
+			has_superuser_candidate = owned_by_superuser;
 		}
 
 		/*
@@ -4245,7 +4262,7 @@ finalNamespacePath(List *oidlist, Oid *firstNS)
 	 * the front, not the back; also notice that we do not check USAGE
 	 * permissions for these.
 	 */
-	if (!list_member_oid(finalPath, PG_CATALOG_NAMESPACE))
+	if (!list_member_oid(finalPath, PG_CATALOG_NAMESPACE) || prohibit_superuser_overrides)
 		finalPath = lcons_oid(PG_CATALOG_NAMESPACE, finalPath);
 
 	if (OidIsValid(myTempNamespace) &&

--- a/src/backend/utils/misc/guc_tables.c
+++ b/src/backend/utils/misc/guc_tables.c
@@ -2188,7 +2188,7 @@ struct config_bool ConfigureNamesBool[] =
 		 gettext_noop("Prevent overriding of functions defined by superuser by non-superuser candidates."),
 		},
 		&prohibit_superuser_overrides,
-		false,
+		true,
 		NULL, NULL, NULL
 	},
 

--- a/src/backend/utils/misc/guc_tables.c
+++ b/src/backend/utils/misc/guc_tables.c
@@ -2183,6 +2183,15 @@ struct config_bool ConfigureNamesBool[] =
 		NULL, NULL, NULL
 	},
 
+	{
+		{"prohibit_superuser_overrides", PGC_SUSET, CLIENT_CONN_STATEMENT,
+		 gettext_noop("Prevent overriding of functions defined by superuser by non-superuser candidates."),
+		},
+		&prohibit_superuser_overrides,
+		false,
+		NULL, NULL, NULL
+	},
+
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, false, NULL, NULL, NULL

--- a/src/include/catalog/namespace.h
+++ b/src/include/catalog/namespace.h
@@ -182,6 +182,7 @@ extern void AtEOSubXact_Namespace(bool isCommit, SubTransactionId mySubid,
 
 /* stuff for search_path GUC variable */
 extern PGDLLIMPORT char *namespace_search_path;
+extern bool prohibit_superuser_overrides;
 
 extern List *fetch_search_path(bool includeImplicit);
 extern int	fetch_search_path_array(Oid *sarray, int sarray_len);

--- a/src/test/regress/expected/stats.out
+++ b/src/test/regress/expected/stats.out
@@ -955,7 +955,7 @@ SELECT wal_bytes > :backend_wal_bytes_before FROM pg_stat_get_backend_wal(pg_bac
 -- Test pg_stat_get_backend_idset() and some allied functions.
 -- In particular, verify that their notion of backend ID matches
 -- our temp schema index.
-SELECT (current_schemas(true))[1] = ('pg_temp_' || beid::text) AS match
+SELECT (current_schemas(true))[2] = ('pg_temp_' || beid::text) AS match
 FROM pg_stat_get_backend_idset() beid
 WHERE pg_stat_get_backend_pid(beid) = pg_backend_pid();
  match 

--- a/src/test/regress/sql/stats.sql
+++ b/src/test/regress/sql/stats.sql
@@ -451,7 +451,7 @@ SELECT wal_bytes > :backend_wal_bytes_before FROM pg_stat_get_backend_wal(pg_bac
 -- Test pg_stat_get_backend_idset() and some allied functions.
 -- In particular, verify that their notion of backend ID matches
 -- our temp schema index.
-SELECT (current_schemas(true))[1] = ('pg_temp_' || beid::text) AS match
+SELECT (current_schemas(true))[2] = ('pg_temp_' || beid::text) AS match
 FROM pg_stat_get_backend_idset() beid
 WHERE pg_stat_get_backend_pid(beid) = pg_backend_pid();
 


### PR DESCRIPTION
### Problem

See https://databricks.slack.com/archives/C092W8NBXC0/p1771421660357509?thread_ts=1771421653.582579&cid=C092W8NBXC0


We have discussed it many times:
https://databricks.slack.com/archives/C092W8NBXC0/p1769006207119519
last time at this Monday compute sync.
Still not quite clear to me if it is possible or not to prevent all such SECs but just by providing safe search_path.

Let me share my current vision of the problem.
Extensions quite often work with schema public and neon users are allows to create object in schema public .  So user can always place some object in schema public which overrides (hides) standard function.

Since PostgreSQL 9.0+, functions are collected from all schemas in the path before resolution. This means adding a schema to search_path can introduce unexpected overload candidates that change which function gets called.

### Solution

1. While selecting function candidates always prefer ones belonging to superuser
2. Always prepend pg_catalog to search_path (Postgres is doing it only if it is not explicitly include in search path)

### Examples of prevented SECs:

```
set prohibit_superuser_overrides = true;
create role somebody;
grant all privileges on schema public to somebody;
grant all privileges on database postgres to somebody;
set role somebody;
CREATE OR REPLACE FUNCTION setval(a text, b int) RETURNS bigint AS $$
BEGIN
   RAISE WARNING 'setval executed by = %', current_user;
   RAISE WARNING 'Current search_path = %', current_setting('search_path'); 
   RETURN pg_catalog.setval(a,b);
END;
$$ LANGUAGE plpgsql;
create sequence myseq;
create view pg_roles as select 1;
set search_path=public,pg_catalog;
set role cloud_admin;
select setval('myseq', 1);
select * from pg_roles;
```



