### PR TITLE
prevent users from creating triggers on tables in anon namespace

### DIFF
--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -355,7 +355,8 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 		}
 
 		// We also prevent users from creating triggers on tables in the anon schema
-		if (strcmp(get_namespace_name(get_rel_namespace(relOid)), "anon") == 0) {
+		char* namespace_name = get_namespace_name(get_rel_namespace(RelationGetRelid(rel)));
+		if (namespace_name != NULL && (strcmp(namespace_name, "anon") == 0)) {
 			aclcheck_error(ACLCHECK_NO_PRIV, get_relkind_objtype(rel->rd_rel->relkind),
 						   RelationGetRelationName(rel));
 		}

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -206,6 +206,7 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 	Oid			existing_constraint_oid = InvalidOid;
 	bool		existing_isInternal = false;
 	bool		existing_isClone = false;
+	char* 	   *namespace_name = NULL;
 
 	if (OidIsValid(relOid))
 		rel = table_open(relOid, ShareRowExclusiveLock);
@@ -355,7 +356,7 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 		}
 
 		// We also prevent users from creating triggers on tables in the anon schema
-		char* namespace_name = get_namespace_name(get_rel_namespace(RelationGetRelid(rel)));
+		namespace_name = get_namespace_name(get_rel_namespace(RelationGetRelid(rel)));
 		if (namespace_name != NULL && (strcmp(namespace_name, "anon") == 0)) {
 			ereport(ERROR,
               (errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -206,7 +206,7 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 	Oid			existing_constraint_oid = InvalidOid;
 	bool		existing_isInternal = false;
 	bool		existing_isClone = false;
-	char* 	   *namespace_name = NULL;
+	char 	   *namespace_name = NULL;
 
 	if (OidIsValid(relOid))
 		rel = table_open(relOid, ShareRowExclusiveLock);

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -357,8 +357,11 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 		// We also prevent users from creating triggers on tables in the anon schema
 		char* namespace_name = get_namespace_name(get_rel_namespace(RelationGetRelid(rel)));
 		if (namespace_name != NULL && (strcmp(namespace_name, "anon") == 0)) {
-			aclcheck_error(ACLCHECK_NO_PRIV, get_relkind_objtype(rel->rd_rel->relkind),
-						   RelationGetRelationName(rel));
+			ereport(ERROR,
+              (errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+               errmsg("cannot create trigger on relation \"%s\": "
+                      "triggers on the anon schema are not permitted",
+                      RelationGetRelationName(rel))));
 		}
 	}
 

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -353,6 +353,12 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 				aclcheck_error(aclresult, get_relkind_objtype(get_rel_relkind(constrrelid)),
 							   get_rel_name(constrrelid));
 		}
+
+		// We also prevent users from creating triggers on tables in the anon schema
+		if (strcmp(get_namespace_name(get_rel_namespace(relOid)), "anon") == 0) {
+			aclcheck_error(ACLCHECK_NO_PRIV, get_relkind_objtype(rel->rd_rel->relkind),
+						   RelationGetRelationName(rel));
+		}
 	}
 
 	/*


### PR DESCRIPTION
This PR proposes a fix to https://github.com/databricks-eng/hadron/pull/4858 by preventing users from creating triggers on tables in the `anon` schema.