### PR TITLE
Injection points SMGR v17

### DIFF
--- a/src/test/modules/injection_points/injection_points.c
+++ b/src/test/modules/injection_points/injection_points.c
@@ -16,6 +16,7 @@
  */
 
 #include "postgres.h"
+#include <time.h>
 
 #include "fmgr.h"
 #include "miscadmin.h"
@@ -59,6 +60,8 @@ typedef struct InjectionPointCondition
 
 	/* ID of the process where the injection point is allowed to run */
 	int			pid;
+	/* probability in [0,1], 1.0 = always */
+	double		prob;
 } InjectionPointCondition;
 
 /*
@@ -88,6 +91,8 @@ static InjectionPointSharedState *inj_state = NULL;
 
 extern PGDLLEXPORT void injection_error(const char *name,
 										const void *private_data);
+extern PGDLLEXPORT void injection_error_prob(const char *name,
+											 const void *private_data);
 extern PGDLLEXPORT void injection_notice(const char *name,
 										 const void *private_data);
 extern PGDLLEXPORT void injection_wait(const char *name,
@@ -95,6 +100,7 @@ extern PGDLLEXPORT void injection_wait(const char *name,
 
 /* track if injection points attached in this process are linked to it */
 static bool injection_point_local = false;
+static double action2prob(const char *action, int pos);
 
 /*
  * Callback for shared memory area initialization.
@@ -180,6 +186,21 @@ injection_error(const char *name, const void *private_data)
 	InjectionPointCondition *condition = (InjectionPointCondition *) private_data;
 
 	if (!injection_point_allowed(condition))
+		return;
+
+	elog(ERROR, "error triggered for injection point %s", name);
+}
+
+void
+injection_error_prob(const char *name, const void *private_data)
+{
+	InjectionPointCondition *condition = (InjectionPointCondition *) private_data;
+
+	if (!injection_point_allowed(condition))
+		return;
+
+	/* Use the probability stored in the condition. */
+	if ((double) rand() / (double) RAND_MAX > condition->prob)
 		return;
 
 	elog(ERROR, "error triggered for injection point %s", name);
@@ -278,6 +299,11 @@ injection_points_attach(PG_FUNCTION_ARGS)
 		function = "injection_notice";
 	else if (strcmp(action, "wait") == 0)
 		function = "injection_wait";
+	else if (strncmp(action, "error-prob-", 11) == 0)
+	{
+		condition.prob = action2prob(action, 11);
+		function = "injection_error_prob";
+	}
 	else
 		elog(ERROR, "incorrect action \"%s\" for injection point creation", action);
 
@@ -401,4 +427,31 @@ injection_points_detach(PG_FUNCTION_ARGS)
 	}
 
 	PG_RETURN_VOID();
+}
+
+/*
+ * Coverts the action name into probability
+ */
+static double action2prob(const char *action, const int pos)
+{
+	/*
+	 * Simple parser: convert "0-01" -> "0.01" then strtod().
+	 */
+	const char *p = action + pos; /* points to "0-01" */
+	double		prob;
+	char	   *endptr;
+	char		buf[32];
+	int			i,
+				j;
+
+	for (i = 0, j = 0; p[i] != '\0' && j < (int) sizeof(buf) - 1; i++)
+	{
+		buf[j++] = (p[i] == '-') ? '.' : p[i];
+	}
+	buf[j] = '\0';
+	errno = 0;
+	prob = strtod(buf, &endptr);
+	if (errno != 0 || endptr == buf || prob < 0.0 || prob > 1.0)
+		elog(ERROR, "invalid probability in action \"%s\"", action);
+	return prob;
 }


### PR DESCRIPTION
We need to test SMGR failures.

This PR adds probability-based injection in the injection_points extension – New error-prob- action so injection points can raise an ERROR with a configurable probability (e.g. for fault-injection tests).