### PR TITLE
Prevent possible search_path attacks

### DIFF
--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -198,7 +198,7 @@ static SubTransactionId myTempNamespaceSubID = InvalidSubTransactionId;
  * of the GUC variable 'search_path'.
  */
 char	   *namespace_search_path = NULL;
-
+bool		prohibit_superuser_overrides;
 
 /* Local functions */
 static void recomputeNamespacePath(void);
@@ -960,6 +960,7 @@ FuncnameGetCandidates(List *names, int nargs, List *argnames,
 	Oid			namespaceId;
 	CatCList   *catlist;
 	int			i;
+	bool		has_superuser_candidate = false;
 
 	/* check for caller error */
 	Assert(nargs >= 0 || !(expand_variadic | expand_defaults));
@@ -1021,6 +1022,22 @@ FuncnameGetCandidates(List *names, int nargs, List *argnames,
 			}
 			if (nsp == NULL)
 				continue;		/* proc is not in search path */
+		}
+
+		/* prohibit overrides under superuser */
+		if (prohibit_superuser_overrides && superuser())
+		{
+			bool owned_by_superuser = superuser_arg(procform->proowner);
+
+			/* If we have superuser condidate, then ignore all non-supoeruser alternatives */
+			if (resultList && has_superuser_candidate && !owned_by_superuser)
+				continue;
+
+			/* If new candidate is owned by superuser then forget all non-superuser candidates */
+			if (owned_by_superuser && !has_superuser_candidate)
+				resultList = NULL;
+
+			has_superuser_candidate = owned_by_superuser;
 		}
 
 		/*
@@ -3918,6 +3935,10 @@ recomputeNamespacePath(void)
 	if (OidIsValid(myTempNamespace) &&
 		!list_member_oid(oidlist, myTempNamespace))
 		oidlist = lcons_oid(myTempNamespace, oidlist);
+
+	/* Always place pg_catalog at the beginning of search path */
+	if (prohibit_superuser_overrides && superuser())
+		oidlist = lcons_oid(PG_CATALOG_NAMESPACE, oidlist);
 
 	/*
 	 * We want to detect the case where the effective value of the base search

--- a/src/include/catalog/namespace.h
+++ b/src/include/catalog/namespace.h
@@ -183,6 +183,7 @@ extern void AtEOSubXact_Namespace(bool isCommit, SubTransactionId mySubid,
 
 /* stuff for search_path GUC variable */
 extern char *namespace_search_path;
+extern bool prohibit_superuser_overrides;
 
 extern List *fetch_search_path(bool includeImplicit);
 extern int	fetch_search_path_array(Oid *sarray, int sarray_len);


### PR DESCRIPTION
## Problem

See https://databricks.slack.com/archives/C092W8NBXC0/p1771421660357509?thread_ts=1771421653.582579&cid=C092W8NBXC0

We have discussed it many times:
https://databricks.slack.com/archives/C092W8NBXC0/p1769006207119519
last time at this Monday compute sync.
Still not quite clear to me if it is possible or not to prevent all such SECs but just by providing safe search_path.

Let me share my current vision of the problem.
Extensions quite often work with schema public and neon users are allows to create object in schema public .  So user can always place some object in schema public which overrides (hides) standard function.

Since PostgreSQL 9.0+, functions are collected from all schemas in the path before resolution. This means adding a schema to search_path can introduce unexpected overload candidates that change which function gets called.

## Solution

While selecting function candidates always prefer ones belonging to superuser
Always prepend `pg_catalog` to `search_path` (Postgres is doing it only if it is not explicitly include in search path)