### PR TITLE
Add extension_is_visible_hook (PG 16)

### DIFF
--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -2216,6 +2216,10 @@ pg_available_extensions(PG_FUNCTION_ARGS)
 			if (strstr(extname, "--"))
 				continue;
 
+			/* Check extension visibility hook */
+			if (extension_is_visible_hook && !extension_is_visible_hook(extname))
+				continue;
+
 			control = read_extension_control_file(extname);
 
 			memset(values, 0, sizeof(values));
@@ -2292,6 +2296,10 @@ pg_available_extension_versions(PG_FUNCTION_ARGS)
 
 			/* ignore it if it's an auxiliary control file */
 			if (strstr(extname, "--"))
+				continue;
+
+			/* Check extension visibility hook */
+			if (extension_is_visible_hook && !extension_is_visible_hook(extname))
 				continue;
 
 			/* read the control file */

--- a/src/backend/utils/fmgr/fmgr.c
+++ b/src/backend/utils/fmgr/fmgr.c
@@ -38,6 +38,7 @@
  */
 PGDLLIMPORT needs_fmgr_hook_type needs_fmgr_hook = NULL;
 PGDLLIMPORT fmgr_hook_type fmgr_hook = NULL;
+PGDLLIMPORT extension_is_visible_hook_type extension_is_visible_hook = NULL;
 
 /*
  * Hashtable for fast lookup of external C functions

--- a/src/include/fmgr.h
+++ b/src/include/fmgr.h
@@ -794,6 +794,9 @@ typedef void (*fmgr_hook_type) (FmgrHookEventType event,
 extern PGDLLIMPORT needs_fmgr_hook_type needs_fmgr_hook;
 extern PGDLLIMPORT fmgr_hook_type fmgr_hook;
 
+typedef bool (*extension_is_visible_hook_type) (const char *extname);
+extern PGDLLIMPORT extension_is_visible_hook_type extension_is_visible_hook;
+
 #define FmgrHookIsNeeded(fn_oid)							\
 	(!needs_fmgr_hook ? false : (*needs_fmgr_hook)(fn_oid))
 


### PR DESCRIPTION
## Summary

Add `extension_is_visible_hook` to PostgreSQL that allows extensions to filter which extensions
are visible in `pg_available_extensions` and `pg_available_extension_versions` catalog views.

## Changes

- `src/include/fmgr.h` — Add `extension_is_visible_hook_type` typedef and `extension_is_visible_hook` extern
- `src/backend/utils/fmgr/fmgr.c` — Initialize `extension_is_visible_hook` to NULL
- `src/backend/commands/extension.c` — Call the hook in `pg_available_extensions()` and `pg_available_extension_versions()` to skip extensions where the hook returns false

The hook follows the standard PostgreSQL hook pattern: when NULL (default), behavior is unchanged.
Extensions can set the hook to filter which extensions are visible in the catalog views.