### PR TITLE
Stabilize portals regression test against synchronize_seqscans (v17)

### DIFF
--- a/src/test/regress/expected/portals.out
+++ b/src/test/regress/expected/portals.out
@@ -1,6 +1,7 @@
 --
 -- Cursor regression tests
 --
+SET synchronize_seqscans = off;
 BEGIN;
 DECLARE foo1 SCROLL CURSOR FOR SELECT * FROM tenk1 ORDER BY unique2;
 DECLARE foo2 SCROLL CURSOR FOR SELECT * FROM tenk2;
@@ -1561,3 +1562,4 @@ fetch all in held_portal;
 (1 row)
 
 reset default_toast_compression;
+reset synchronize_seqscans;

--- a/src/test/regress/sql/portals.sql
+++ b/src/test/regress/sql/portals.sql
@@ -2,6 +2,8 @@
 -- Cursor regression tests
 --
 
+SET synchronize_seqscans = off;
+
 BEGIN;
 
 DECLARE foo1 SCROLL CURSOR FOR SELECT * FROM tenk1 ORDER BY unique2;
@@ -605,3 +607,4 @@ drop table toasted_data;
 fetch all in held_portal;
 
 reset default_toast_compression;
+reset synchronize_seqscans;


### PR DESCRIPTION
## Problem

The `portals` pg_regress test declares cursors on `tenk2` without `ORDER BY`, relying on heap scan order for expected output. When `synchronize_seqscans` is on (the default) and another backend in the same parallel group is concurrently scanning `tenk2`, the new scan can start mid-table, producing rows in a different order than the `.out` file expects.

The issue surfaces more on slower storages (for example network-attached), where scan timing differences widen the window for concurrent scan synchronization.

## Summary of changes

- Add `SET synchronize_seqscans = off;` at the top of `portals.sql` and `RESET synchronize_seqscans;` at the end
- Based on the patch from https://www.postgresql.org/message-id/CAEze2Wi0hg46bcvLQrjid6Kvbb+NSR1N5OKbDNfHy2J=JutJ=Q@mail.gmail.com
