### PR TITLE
Move extension_is_visible_hook to extension.h/extension.c (PG 14)

### DIFF
--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -74,6 +74,9 @@
 bool		creating_extension = false;
 Oid			CurrentExtensionObject = InvalidOid;
 
+/* Hook for filtering extensions in pg_available_extensions */
+extension_is_visible_hook_type extension_is_visible_hook = NULL;
+
 /*
  * Internal data structure to hold the results of parsing a control file
  */

--- a/src/backend/utils/fmgr/fmgr.c
+++ b/src/backend/utils/fmgr/fmgr.c
@@ -37,7 +37,6 @@
  */
 PGDLLIMPORT needs_fmgr_hook_type needs_fmgr_hook = NULL;
 PGDLLIMPORT fmgr_hook_type fmgr_hook = NULL;
-PGDLLIMPORT extension_is_visible_hook_type extension_is_visible_hook = NULL;
 
 /*
  * Hashtable for fast lookup of external C functions

--- a/src/include/commands/extension.h
+++ b/src/include/commands/extension.h
@@ -54,4 +54,7 @@ extern Oid	get_function_sibling_type(Oid funcoid, const char *typname);
 extern ObjectAddress AlterExtensionNamespace(const char *extensionName, const char *newschema,
 											 Oid *oldschema);
 
+typedef bool (*extension_is_visible_hook_type) (const char *extname);
+extern PGDLLIMPORT extension_is_visible_hook_type extension_is_visible_hook;
+
 #endif							/* EXTENSION_H */

--- a/src/include/fmgr.h
+++ b/src/include/fmgr.h
@@ -771,9 +771,6 @@ typedef void (*fmgr_hook_type) (FmgrHookEventType event,
 extern PGDLLIMPORT needs_fmgr_hook_type needs_fmgr_hook;
 extern PGDLLIMPORT fmgr_hook_type fmgr_hook;
 
-typedef bool (*extension_is_visible_hook_type) (const char *extname);
-extern PGDLLIMPORT extension_is_visible_hook_type extension_is_visible_hook;
-
 #define FmgrHookIsNeeded(fn_oid)							\
 	(!needs_fmgr_hook ? false : (*needs_fmgr_hook)(fn_oid))
 


### PR DESCRIPTION
## Summary

Move `extension_is_visible_hook` declaration from `fmgr.h`/`fmgr.c` to `commands/extension.h`/`extension.c` where it conceptually belongs.

Follow-up to the initial hook addition — the hook is about extension catalog filtering, not function manager operations, so it belongs alongside the other extension management declarations.

## Changes

- `src/include/fmgr.h` — Remove hook typedef and extern (moved)
- `src/backend/utils/fmgr/fmgr.c` — Remove hook variable init (moved)
- `src/include/commands/extension.h` — Add hook typedef and extern
- `src/backend/commands/extension.c` — Add hook variable init alongside other globals