### PR TITLE
Backport injection_points: injection_points_attach overload with library, function, and private data (v18)

### DIFF
--- a/src/backend/utils/misc/injection_point.c
+++ b/src/backend/utils/misc/injection_point.c
@@ -584,3 +584,49 @@ IsInjectionPointAttached(const char *name)
 	return false;				/* silence compiler */
 #endif
 }
+
+/*
+ * Retrieve a list of all the injection points currently attached.
+ *
+ * This list is palloc'd in the current memory context.
+ */
+List *
+InjectionPointList(void)
+{
+#ifdef USE_INJECTION_POINTS
+	List	   *inj_points = NIL;
+	uint32		max_inuse;
+
+	LWLockAcquire(InjectionPointLock, LW_SHARED);
+
+	max_inuse = pg_atomic_read_u32(&ActiveInjectionPoints->max_inuse);
+
+	for (uint32 idx = 0; idx < max_inuse; idx++)
+	{
+		InjectionPointEntry *entry;
+		InjectionPointData *inj_point;
+		uint64		generation;
+
+		entry = &ActiveInjectionPoints->entries[idx];
+		generation = pg_atomic_read_u64(&entry->generation);
+
+		/* skip free slots */
+		if (generation % 2 == 0)
+			continue;
+
+		inj_point = palloc0_object(InjectionPointData);
+		inj_point->name = pstrdup(entry->name);
+		inj_point->library = pstrdup(entry->library);
+		inj_point->function = pstrdup(entry->function);
+		inj_points = lappend(inj_points, inj_point);
+	}
+
+	LWLockRelease(InjectionPointLock);
+
+	return inj_points;
+
+#else
+	elog(ERROR, "Injection points are not supported by this build");
+	return NIL;				/* keep compiler quiet */
+#endif
+}

--- a/src/include/utils/injection_point.h
+++ b/src/include/utils/injection_point.h
@@ -11,6 +11,19 @@
 #ifndef INJECTION_POINT_H
 #define INJECTION_POINT_H
 
+#include "nodes/pg_list.h"
+
+/*
+ * Injection point data, used when retrieving a list of all the attached
+ * injection points.
+ */
+typedef struct InjectionPointData
+{
+	const char *name;
+	const char *library;
+	const char *function;
+} InjectionPointData;
+
 /*
  * Injection points require --enable-injection-points.
  */
@@ -46,6 +59,9 @@ extern void InjectionPointRun(const char *name, void *arg);
 extern void InjectionPointCached(const char *name, void *arg);
 extern bool IsInjectionPointAttached(const char *name);
 extern bool InjectionPointDetach(const char *name);
+
+/* Get the current set of injection points attached */
+extern List *InjectionPointList(void);
 
 #ifdef EXEC_BACKEND
 extern PGDLLIMPORT struct InjectionPointsCtl *ActiveInjectionPoints;

--- a/src/test/modules/injection_points/expected/injection_points.out
+++ b/src/test/modules/injection_points/expected/injection_points.out
@@ -298,5 +298,45 @@ SELECT injection_points_detach('TestConditionLocal1');
  
 (1 row)
 
+-- Function variant for attach.
+SELECT injection_points_attach(NULL, NULL, NULL, NULL);
+ERROR:  injection point name cannot be NULL
+SELECT injection_points_attach('injection_points', NULL, NULL, NULL);
+ERROR:  injection point library cannot be NULL
+SELECT injection_points_attach('injection_points', 'injection_notice', NULL, NULL);
+ERROR:  injection point function cannot be NULL
+SELECT injection_points_attach('TestInjectionNoticeFunc',
+  'injection_points', 'injection_notice', NULL);
+ injection_points_attach 
+-------------------------
+ 
+(1 row)
+
+SELECT point_name, library, function FROM injection_points_list()
+  ORDER BY point_name COLLATE "C";
+       point_name        |     library      |     function     
+-------------------------+------------------+------------------
+ TestInjectionNoticeFunc | injection_points | injection_notice
+(1 row)
+
+SELECT injection_points_run('TestInjectionNoticeFunc', NULL); -- notice
+NOTICE:  notice triggered for injection point TestInjectionNoticeFunc
+ injection_points_run 
+----------------------
+ 
+(1 row)
+
+SELECT injection_points_detach('TestInjectionNoticeFunc');
+ injection_points_detach 
+-------------------------
+ 
+(1 row)
+
+SELECT point_name, library, function FROM injection_points_list()
+  ORDER BY point_name COLLATE "C";
+ point_name | library | function 
+------------+---------+----------
+(0 rows)
+
 DROP EXTENSION injection_points;
 DROP FUNCTION wait_pid;

--- a/src/test/modules/injection_points/injection_points--1.0.sql
+++ b/src/test/modules/injection_points/injection_points--1.0.sql
@@ -15,6 +15,18 @@ AS 'MODULE_PATHNAME', 'injection_points_attach'
 LANGUAGE C STRICT PARALLEL UNSAFE;
 
 --
+-- injection_points_attach()
+--
+-- Attaches a function to the given injection point, with library name,
+-- function name and private data.
+--
+CREATE FUNCTION injection_points_attach(IN point_name TEXT,
+    IN library_name TEXT, IN function_name TEXT, IN private_data BYTEA)
+RETURNS void
+AS 'MODULE_PATHNAME', 'injection_points_attach_func'
+LANGUAGE C PARALLEL UNSAFE;
+
+--
 -- injection_points_load()
 --
 -- Load an injection point already attached.
@@ -76,6 +88,18 @@ CREATE FUNCTION injection_points_detach(IN point_name TEXT)
 RETURNS void
 AS 'MODULE_PATHNAME', 'injection_points_detach'
 LANGUAGE C STRICT PARALLEL UNSAFE;
+
+--
+-- injection_points_list()
+--
+-- List of all the injection points currently attached.
+--
+CREATE FUNCTION injection_points_list(OUT point_name text,
+    OUT library text,
+    OUT function text)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME', 'injection_points_list'
+LANGUAGE C STRICT VOLATILE PARALLEL RESTRICTED;
 
 --
 -- injection_points_stats_numcalls()

--- a/src/test/modules/injection_points/injection_points.c
+++ b/src/test/modules/injection_points/injection_points.c
@@ -18,6 +18,7 @@
 #include "postgres.h"
 
 #include "fmgr.h"
+#include "funcapi.h"
 #include "injection_stats.h"
 #include "miscadmin.h"
 #include "nodes/pg_list.h"
@@ -31,6 +32,7 @@
 #include "utils/guc.h"
 #include "utils/injection_point.h"
 #include "utils/memutils.h"
+#include "utils/tuplestore.h"
 #include "utils/wait_event.h"
 
 PG_MODULE_MAGIC;
@@ -391,6 +393,47 @@ injection_points_attach(PG_FUNCTION_ARGS)
 }
 
 /*
+ * SQL function for creating an injection point with library name, function
+ * name and private data.
+ */
+PG_FUNCTION_INFO_V1(injection_points_attach_func);
+Datum
+injection_points_attach_func(PG_FUNCTION_ARGS)
+{
+	char	   *name;
+	char	   *lib_name;
+	char	   *function;
+	bytea	   *private_data = NULL;
+	int			private_data_size = 0;
+
+	if (PG_ARGISNULL(0))
+		elog(ERROR, "injection point name cannot be NULL");
+	if (PG_ARGISNULL(1))
+		elog(ERROR, "injection point library cannot be NULL");
+	if (PG_ARGISNULL(2))
+		elog(ERROR, "injection point function cannot be NULL");
+
+	name = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	lib_name = text_to_cstring(PG_GETARG_TEXT_PP(1));
+	function = text_to_cstring(PG_GETARG_TEXT_PP(2));
+
+	if (!PG_ARGISNULL(3))
+	{
+		private_data = PG_GETARG_BYTEA_PP(3);
+		private_data_size = VARSIZE_ANY_EXHDR(private_data);
+	}
+
+	pgstat_report_inj_fixed(1, 0, 0, 0, 0);
+	if (private_data != NULL)
+		InjectionPointAttach(name, lib_name, function, VARDATA_ANY(private_data),
+							 private_data_size);
+	else
+		InjectionPointAttach(name, lib_name, function, NULL,
+							 0);
+	PG_RETURN_VOID();
+}
+
+/*
  * SQL function for loading an injection point.
  */
 PG_FUNCTION_INFO_V1(injection_points_load);
@@ -543,6 +586,44 @@ injection_points_detach(PG_FUNCTION_ARGS)
 	pgstat_drop_inj(name);
 
 	PG_RETURN_VOID();
+}
+
+/*
+ * SQL function for listing all the injection points attached.
+ */
+PG_FUNCTION_INFO_V1(injection_points_list);
+Datum
+injection_points_list(PG_FUNCTION_ARGS)
+{
+#define NUM_INJECTION_POINTS_LIST 3
+	ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
+	List	   *inj_points;
+	ListCell   *lc;
+
+	/* Build a tuplestore to return our results in */
+	InitMaterializedSRF(fcinfo, 0);
+
+	inj_points = InjectionPointList();
+
+	foreach(lc, inj_points)
+	{
+		Datum		values[NUM_INJECTION_POINTS_LIST];
+		bool		nulls[NUM_INJECTION_POINTS_LIST];
+		InjectionPointData *inj_point = lfirst(lc);
+
+		memset(values, 0, sizeof(values));
+		memset(nulls, 0, sizeof(nulls));
+
+		values[0] = PointerGetDatum(cstring_to_text(inj_point->name));
+		values[1] = PointerGetDatum(cstring_to_text(inj_point->library));
+		values[2] = PointerGetDatum(cstring_to_text(inj_point->function));
+
+		/* shove row into tuplestore */
+		tuplestore_putvalues(rsinfo->setResult, rsinfo->setDesc, values, nulls);
+	}
+
+	return (Datum) 0;
+#undef NUM_INJECTION_POINTS_LIST
 }
 
 

--- a/src/test/modules/injection_points/sql/injection_points.sql
+++ b/src/test/modules/injection_points/sql/injection_points.sql
@@ -85,5 +85,19 @@ SELECT injection_points_detach('TestConditionError');
 SELECT injection_points_attach('TestConditionLocal1', 'error');
 SELECT injection_points_detach('TestConditionLocal1');
 
+-- Function variant for attach.
+SELECT injection_points_attach(NULL, NULL, NULL, NULL);
+SELECT injection_points_attach('injection_points', NULL, NULL, NULL);
+SELECT injection_points_attach('injection_points', 'injection_notice', NULL, NULL);
+SELECT injection_points_attach('TestInjectionNoticeFunc',
+  'injection_points', 'injection_notice', NULL);
+SELECT point_name, library, function FROM injection_points_list()
+  ORDER BY point_name COLLATE "C";
+SELECT injection_points_run('TestInjectionNoticeFunc', NULL); -- notice
+SELECT injection_points_detach('TestInjectionNoticeFunc');
+
+SELECT point_name, library, function FROM injection_points_list()
+  ORDER BY point_name COLLATE "C";
+
 DROP EXTENSION injection_points;
 DROP FUNCTION wait_pid;


### PR DESCRIPTION
This change backports[ postgres/postgres@16a2f70](https://github.com/postgres/postgres/commit/16a2f706951edc1b284a66902c9e582217d37d31), which adds a second overload of `injection_points_attach` that takes an explicit library name, function name, and optional bytea private data, so tests can attach callbacks without hard-coding the injection_points module wrapper.
Because that commit’s regression test lists attached points, it also adds `InjectionPointList()` in the core and exposes it via `injection_points_list()` in the injection_points test extension, matching upstream.
The injection_points SQL regression test and expected output are extended accordingly.
Note: injection_points--1.0.sql is updated; existing databases that already have the extension may need a separate upgrade script if you rely on ALTER EXTENSION ... UPDATE rather than recreating the extension.