### PR TITLE
Backport injection_points: injection_points_attach overload with library, function, and private data (v17)

### DIFF
--- a/src/backend/utils/misc/injection_point.c
+++ b/src/backend/utils/misc/injection_point.c
@@ -335,8 +335,10 @@ InjectionPointAttach(const char *name,
 	entry->library[INJ_LIB_MAXLEN - 1] = '\0';
 	strlcpy(entry->function, function, sizeof(entry->function));
 	entry->function[INJ_FUNC_MAXLEN - 1] = '\0';
-	if (private_data != NULL)
+	if (private_data != NULL && private_data_size > 0)
 		memcpy(entry->private_data, private_data, private_data_size);
+	else
+		memset(entry->private_data, 0, sizeof(entry->private_data));
 
 	pg_write_barrier();
 	pg_atomic_write_u64(&entry->generation, generation + 1);

--- a/src/test/modules/injection_points/expected/injection_points.out
+++ b/src/test/modules/injection_points/expected/injection_points.out
@@ -208,5 +208,32 @@ SELECT injection_points_detach('TestConditionLocal1');
  
 (1 row)
 
+-- Function variant for attach.
+SELECT injection_points_attach(NULL, NULL, NULL, NULL);
+ERROR:  injection point name cannot be NULL
+SELECT injection_points_attach('injection_points', NULL, NULL, NULL);
+ERROR:  injection point library cannot be NULL
+SELECT injection_points_attach('injection_points', 'injection_notice', NULL, NULL);
+ERROR:  injection point function cannot be NULL
+SELECT injection_points_attach('TestInjectionNoticeFunc',
+    'injection_points', 'injection_notice', NULL);
+ injection_points_attach 
+-------------------------
+ 
+(1 row)
+
+SELECT injection_points_run('TestInjectionNoticeFunc'); -- notice
+NOTICE:  notice triggered for injection point TestInjectionNoticeFunc
+ injection_points_run 
+----------------------
+ 
+(1 row)
+
+SELECT injection_points_detach('TestInjectionNoticeFunc');
+ injection_points_detach 
+-------------------------
+ 
+(1 row)
+
 DROP EXTENSION injection_points;
 DROP FUNCTION wait_pid;

--- a/src/test/modules/injection_points/injection_points--1.0.sql
+++ b/src/test/modules/injection_points/injection_points--1.0.sql
@@ -15,6 +15,18 @@ AS 'MODULE_PATHNAME', 'injection_points_attach'
 LANGUAGE C STRICT PARALLEL UNSAFE;
 
 --
+-- injection_points_attach()
+--
+-- Attaches a function to the given injection point, with library name,
+-- function name and private data.
+--
+CREATE FUNCTION injection_points_attach(IN point_name TEXT,
+    IN library_name TEXT, IN function_name TEXT, IN private_data BYTEA)
+RETURNS void
+AS 'MODULE_PATHNAME', 'injection_points_attach_func'
+LANGUAGE C PARALLEL UNSAFE;
+
+--
 -- injection_points_run()
 --
 -- Executes the action attached to the injection point.

--- a/src/test/modules/injection_points/injection_points.c
+++ b/src/test/modules/injection_points/injection_points.c
@@ -18,6 +18,7 @@
 #include "postgres.h"
 
 #include "fmgr.h"
+#include "varatt.h"
 #include "miscadmin.h"
 #include "nodes/pg_list.h"
 #include "nodes/value.h"
@@ -299,6 +300,46 @@ injection_points_attach(PG_FUNCTION_ARGS)
 		inj_list_local = lappend(inj_list_local, makeString(pstrdup(name)));
 		MemoryContextSwitchTo(oldctx);
 	}
+	PG_RETURN_VOID();
+}
+
+/*
+ * SQL function for creating an injection point with library name, function
+ * name and private data.
+ */
+PG_FUNCTION_INFO_V1(injection_points_attach_func);
+Datum
+injection_points_attach_func(PG_FUNCTION_ARGS)
+{
+	char	   *name;
+	char	   *lib_name;
+	char	   *function;
+	bytea	   *private_data = NULL;
+	int			private_data_size = 0;
+
+	if (PG_ARGISNULL(0))
+		elog(ERROR, "injection point name cannot be NULL");
+	if (PG_ARGISNULL(1))
+		elog(ERROR, "injection point library cannot be NULL");
+	if (PG_ARGISNULL(2))
+		elog(ERROR, "injection point function cannot be NULL");
+
+	name = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	lib_name = text_to_cstring(PG_GETARG_TEXT_PP(1));
+	function = text_to_cstring(PG_GETARG_TEXT_PP(2));
+
+	if (!PG_ARGISNULL(3))
+	{
+		private_data = PG_GETARG_BYTEA_PP(3);
+		private_data_size = VARSIZE_ANY_EXHDR(private_data);
+	}
+
+	if (private_data != NULL)
+		InjectionPointAttach(name, lib_name, function, VARDATA_ANY(private_data),
+							 private_data_size);
+	else
+		InjectionPointAttach(name, lib_name, function, NULL,
+							 0);
 	PG_RETURN_VOID();
 }
 

--- a/src/test/modules/injection_points/sql/injection_points.sql
+++ b/src/test/modules/injection_points/sql/injection_points.sql
@@ -66,5 +66,14 @@ SELECT injection_points_detach('TestConditionError');
 SELECT injection_points_attach('TestConditionLocal1', 'error');
 SELECT injection_points_detach('TestConditionLocal1');
 
+-- Function variant for attach.
+SELECT injection_points_attach(NULL, NULL, NULL, NULL);
+SELECT injection_points_attach('injection_points', NULL, NULL, NULL);
+SELECT injection_points_attach('injection_points', 'injection_notice', NULL, NULL);
+SELECT injection_points_attach('TestInjectionNoticeFunc',
+    'injection_points', 'injection_notice', NULL);
+SELECT injection_points_run('TestInjectionNoticeFunc'); -- notice
+SELECT injection_points_detach('TestInjectionNoticeFunc');
+
 DROP EXTENSION injection_points;
 DROP FUNCTION wait_pid;


### PR DESCRIPTION
Backports [postgres@16a2f70](https://github.com/postgres/postgres/commit/16a2f706951edc1b284a66902c9e582217d37d31): a second `injection_points_attach` entry point that forwards to `InjectionPointAttach()` with an explicit library name, function name, and optional bytea private data, so tests can attach callbacks without going only through the action-string API.
Changes:
* injection_points--1.0.sql: `CREATE FUNCTION` overload calling injection_points_attach_func (non-STRICT so private_data may be NULL).
* injection_points.c: implement `injection_points_attach_func`, validate required arguments, pass bytea payload into `InjectionPointAttach`; include `varatt.h` for VARSIZE_ANY_EXHDR / VARDATA_ANY.
injection_point.c: when no private payload is stored, zero the shmem private_data buffer so “NULL / empty” attach behaves deterministically on reused slots.
* Regression: extend injection_points SQL/expected with NULL-argument errors, attach/run/detach via injection_notice.
Notes vs upstream: `pgstat_report_inj_fixed` omitted (not in this tree). Tests do not use `injection_points_list()` (not available here); injection_points_run stays single-argument.