### PR TITLE
give replica startup process priority in acquiring locks

### DIFF
--- a/src/backend/storage/lmgr/lwlock.c
+++ b/src/backend/storage/lmgr/lwlock.c
@@ -79,6 +79,7 @@
 #include "miscadmin.h"
 #include "pg_trace.h"
 #include "pgstat.h"
+#include "access/xlogrecovery.h"
 #include "port/pg_bitutils.h"
 #include "postmaster/postmaster.h"
 #include "replication/slot.h"
@@ -249,6 +250,8 @@ int			NamedLWLockTrancheRequests = 0;
 
 /* points to data in shared memory: */
 NamedLWLockTranche *NamedLWLockTrancheArray = NULL;
+
+bool startupProcessLockPriority = false; /* NEON: GUC is defined in neon extension */
 
 static void InitializeLWLocks(void);
 static inline void LWLockReportWaitStart(LWLock *lock);
@@ -1082,7 +1085,8 @@ LWLockQueueSelf(LWLock *lock, LWLockMode mode)
 	MyProc->lwWaitMode = mode;
 
 	/* LW_WAIT_UNTIL_FREE waiters are always at the front of the queue */
-	if (mode == LW_WAIT_UNTIL_FREE)
+/* NEON: Give priority to startup process when GUC is enabled */
+	if (mode == LW_WAIT_UNTIL_FREE || (startupProcessLockPriority && AmStartupProcess()))
 		proclist_push_head(&lock->waiters, MyProc->pgprocno, lwWaitLink);
 	else
 		proclist_push_tail(&lock->waiters, MyProc->pgprocno, lwWaitLink);

--- a/src/include/storage/lwlock.h
+++ b/src/include/storage/lwlock.h
@@ -82,6 +82,9 @@ typedef struct NamedLWLockTranche
 extern PGDLLIMPORT NamedLWLockTranche *NamedLWLockTrancheArray;
 extern PGDLLIMPORT int NamedLWLockTrancheRequests;
 
+/* NEON: GUC from neon ext that gives Replica Standby process priority to acquire a lock */
+extern PGDLLIMPORT bool startupProcessLockPriority;
+
 /* Names for fixed lwlocks */
 #include "storage/lwlocknames.h"
 


### PR DESCRIPTION
Give the replica startup process priority in acquiring locks to combat replica lag. More details in https://github.com/databricks-eng/hadron/pull/5238