### PR TITLE
give replica startup process priority in acquiring locks

### DIFF
--- a/src/backend/storage/lmgr/lwlock.c
+++ b/src/backend/storage/lmgr/lwlock.c
@@ -79,6 +79,7 @@
 #include "miscadmin.h"
 #include "pg_trace.h"
 #include "pgstat.h"
+#include "access/xlogrecovery.h"
 #include "port/pg_bitutils.h"
 #include "storage/proc.h"
 #include "storage/proclist.h"
@@ -237,6 +238,8 @@ int			NamedLWLockTrancheRequests = 0;
 
 /* points to data in shared memory: */
 NamedLWLockTranche *NamedLWLockTrancheArray = NULL;
+
+bool startupProcessLockPriority = false; /* NEON: GUC is defined in neon extension */
 
 static void InitializeLWLocks(void);
 static inline void LWLockReportWaitStart(LWLock *lock);
@@ -1067,7 +1070,7 @@ LWLockQueueSelf(LWLock *lock, LWLockMode mode)
 	MyProc->lwWaitMode = mode;
 
 	/* LW_WAIT_UNTIL_FREE waiters are always at the front of the queue */
-	if (mode == LW_WAIT_UNTIL_FREE)
+	if (mode == LW_WAIT_UNTIL_FREE || (startupProcessLockPriority && AmStartupProcess()))
 		proclist_push_head(&lock->waiters, MyProcNumber, lwWaitLink);
 	else
 		proclist_push_tail(&lock->waiters, MyProcNumber, lwWaitLink);

--- a/src/include/storage/lwlock.h
+++ b/src/include/storage/lwlock.h
@@ -83,6 +83,9 @@ typedef struct NamedLWLockTranche
 extern PGDLLIMPORT NamedLWLockTranche *NamedLWLockTrancheArray;
 extern PGDLLIMPORT int NamedLWLockTrancheRequests;
 
+/* NEON: GUC from neon ext that gives Replica Standby process priority to acquire a lock */
+extern PGDLLIMPORT bool startupProcessLockPriority;
+
 /*
  * It's a bit odd to declare NUM_BUFFER_PARTITIONS and NUM_LOCK_PARTITIONS
  * here, but we need them to figure out offsets within MainLWLockArray, and


### PR DESCRIPTION
Give the replica startup process priority in acquiring locks to combat replica lag. More details in https://github.com/databricks-eng/hadron/pull/5238